### PR TITLE
[MM-11148] Convert mattermod to use structured logging #10315

### DIFF
--- a/config/config-mattermod.json
+++ b/config/config-mattermod.json
@@ -74,5 +74,18 @@
     "AWSDnsSuffix": "",
 
     "MattermostWebhookURL": "",
-    "MattermostWebhookFooter": ""
+    "MattermostWebhookFooter": "",
+
+    "LogSettings": {
+        "EnableConsole": true,
+        "ConsoleLevel": "DEBUG",
+        "ConsoleJson": true,
+        "EnableFile": true,
+        "FileLevel": "INFO",
+        "FileJson": true,
+        "FileFormat": "",
+        "FileLocation": "",
+        "EnableWebhookDebugging": true,
+        "EnableDiagnostics": true
+    },
 }

--- a/config/config-mattermod.json
+++ b/config/config-mattermod.json
@@ -84,8 +84,6 @@
         "FileLevel": "INFO",
         "FileJson": true,
         "FileFormat": "",
-        "FileLocation": "",
-        "EnableWebhookDebugging": true,
-        "EnableDiagnostics": true
+        "FileLocation": ""
     }
 }

--- a/config/config-mattermod.json
+++ b/config/config-mattermod.json
@@ -87,5 +87,5 @@
         "FileLocation": "",
         "EnableWebhookDebugging": true,
         "EnableDiagnostics": true
-    },
+    }
 }

--- a/server/config.go
+++ b/server/config.go
@@ -127,12 +127,14 @@ func LoadConfig(fileName string) {
 	file, err := os.Open(fileName)
 	if err != nil {
 		mlog.Critical(fmt.Sprintf("Error opening config file=%v, err=%v", fileName, err.Error()))
+		panic(err.Error())
 	}
 
 	decoder := json.NewDecoder(file)
 	err = decoder.Decode(Config)
 	if err != nil {
 		mlog.Critical(fmt.Sprintf("Error decoding config file=%v, err=", fileName, err.Error()))
+		panic(err.Error())
 	}
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -125,14 +125,14 @@ func LoadConfig(fileName string) {
 
 	file, err := os.Open(fileName)
 	if err != nil {
-		mlog.Critical("Error opening config file", mlog.String("filename", fileName), mlog.String("config", err.Error()))
+		mlog.Critical("Error opening config file", mlog.String("filename", fileName), mlog.Err(err))
 		panic(err.Error())
 	}
 
 	decoder := json.NewDecoder(file)
 	err = decoder.Decode(Config)
 	if err != nil {
-		mlog.Critical("Error decoding config file", mlog.String("filename", fileName), mlog.String("config", err.Error()))
+		mlog.Critical("Error decoding config file", mlog.String("filename", fileName), mlog.Err(err))
 		panic(err.Error())
 	}
 }

--- a/server/config.go
+++ b/server/config.go
@@ -5,11 +5,13 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/mattermost/mattermost-server/mlog"
 )
 
 type LabelResponse struct {
@@ -120,17 +122,17 @@ func FindConfigFile(fileName string) string {
 
 func LoadConfig(fileName string) {
 	fileName = FindConfigFile(fileName)
-	LogInfo("Loading " + fileName)
+	mlog.Info(fmt.Sprintf("Loading %v", fileName))
 
 	file, err := os.Open(fileName)
 	if err != nil {
-		LogCritical("Error opening config file=" + fileName + ", err=" + err.Error())
+		mlog.Critical(fmt.Sprintf("Error opening config file=%v, err=%v", fileName, err.Error()))
 	}
 
 	decoder := json.NewDecoder(file)
 	err = decoder.Decode(Config)
 	if err != nil {
-		LogCritical("Error decoding config file=" + fileName + ", err=" + err.Error())
+		mlog.Critical(fmt.Sprintf("Error decoding config file=%v, err=", fileName, err.Error()))
 	}
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -93,7 +93,7 @@ type PRServerConfig struct {
 	MattermostWebhookURL    string
 	MattermostWebhookFooter string
 
-	LoggerConfiguration struct {
+	LogSettings struct {
 		EnableConsole bool
 		ConsoleJson   bool
 		ConsoleLevel  string

--- a/server/config.go
+++ b/server/config.go
@@ -122,7 +122,7 @@ func FindConfigFile(fileName string) string {
 
 func LoadConfig(fileName string) {
 	fileName = FindConfigFile(fileName)
-	mlog.Info(fmt.Sprintf("Loading %v", fileName))
+	mlog.Info("Loading config", mlog.String("filename", fileName))
 
 	file, err := os.Open(fileName)
 	if err != nil {

--- a/server/config.go
+++ b/server/config.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -126,14 +125,14 @@ func LoadConfig(fileName string) {
 
 	file, err := os.Open(fileName)
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("Error opening config file=%v, err=%v", fileName, err.Error()))
+		mlog.Critical("Error opening config file", mlog.String("filename", fileName), mlog.String("config", err.Error()))
 		panic(err.Error())
 	}
 
 	decoder := json.NewDecoder(file)
 	err = decoder.Decode(Config)
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("Error decoding config file=%v, err=", fileName, err.Error()))
+		mlog.Critical("Error decoding config file", mlog.String("filename", fileName), mlog.String("config", err.Error()))
 		panic(err.Error())
 	}
 }

--- a/server/config.go
+++ b/server/config.go
@@ -90,6 +90,16 @@ type PRServerConfig struct {
 
 	MattermostWebhookURL    string
 	MattermostWebhookFooter string
+
+	LoggerConfiguration struct {
+		EnableConsole bool
+		ConsoleJson   bool
+		ConsoleLevel  string
+		EnableFile    bool
+		FileJson      bool
+		FileLevel     string
+		FileLocation  string
+	}
 }
 
 var Config *PRServerConfig = &PRServerConfig{}

--- a/server/github.go
+++ b/server/github.go
@@ -4,8 +4,6 @@
 package server
 
 import (
-	"fmt"
-
 	"github.com/google/go-github/github"
 	"github.com/mattermost/mattermost-mattermod/model"
 	"github.com/mattermost/mattermost-server/mlog"
@@ -89,7 +87,7 @@ func commentOnIssue(repoOwner, repoName string, number int, comment string) {
 	client := NewGithubClient()
 	_, _, err := client.Issues.CreateComment(repoOwner, repoName, number, &github.IssueComment{Body: &comment})
 	if err != nil {
-		mlog.Error(fmt.Sprintf("Error: %v", err.Error()))
+		mlog.Error("Error", mlog.String("issueerror", err.Error()))
 	}
 	mlog.Info("Finished commenting")
 }

--- a/server/github.go
+++ b/server/github.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-github/github"
 	"github.com/mattermost/mattermost-mattermod/model"
+	"github.com/mattermost/mattermost-server/mlog"
 	"golang.org/x/oauth2"
 )
 
@@ -88,7 +89,7 @@ func commentOnIssue(repoOwner, repoName string, number int, comment string) {
 	client := NewGithubClient()
 	_, _, err := client.Issues.CreateComment(repoOwner, repoName, number, &github.IssueComment{Body: &comment})
 	if err != nil {
-		LogError("Error: ", err)
+		LogError("Error: ", mlog.String("err", err.Error()))
 	}
 	LogInfo("Finished commenting")
 }

--- a/server/github.go
+++ b/server/github.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/google/go-github/github"
 	"github.com/mattermost/mattermost-mattermod/model"
@@ -86,7 +85,7 @@ func LabelsToStringArray(labels []*github.Label) []string {
 }
 
 func commentOnIssue(repoOwner, repoName string, number int, comment string) {
-	mlog.Info(fmt.Sprintf("Commenting on issue %v Comment: %v", strconv.Itoa(number), comment))
+	mlog.Info("Commenting on issue", mlog.Int("issue", number), mlog.String("comment", comment))
 	client := NewGithubClient()
 	_, _, err := client.Issues.CreateComment(repoOwner, repoName, number, &github.IssueComment{Body: &comment})
 	if err != nil {

--- a/server/github.go
+++ b/server/github.go
@@ -87,7 +87,7 @@ func commentOnIssue(repoOwner, repoName string, number int, comment string) {
 	client := NewGithubClient()
 	_, _, err := client.Issues.CreateComment(repoOwner, repoName, number, &github.IssueComment{Body: &comment})
 	if err != nil {
-		mlog.Error("Error", mlog.String("issue_error", err.Error()))
+		mlog.Error("Error", mlog.Err(err))
 	}
 	mlog.Info("Finished commenting")
 }

--- a/server/github.go
+++ b/server/github.go
@@ -87,7 +87,7 @@ func commentOnIssue(repoOwner, repoName string, number int, comment string) {
 	client := NewGithubClient()
 	_, _, err := client.Issues.CreateComment(repoOwner, repoName, number, &github.IssueComment{Body: &comment})
 	if err != nil {
-		mlog.Error("Error", mlog.String("issueerror", err.Error()))
+		mlog.Error("Error", mlog.String("issue_error", err.Error()))
 	}
 	mlog.Info("Finished commenting")
 }

--- a/server/github.go
+++ b/server/github.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/google/go-github/github"
@@ -85,11 +86,11 @@ func LabelsToStringArray(labels []*github.Label) []string {
 }
 
 func commentOnIssue(repoOwner, repoName string, number int, comment string) {
-	LogInfo("Commenting on issue " + strconv.Itoa(number) + " Comment: " + comment)
+	mlog.Info(fmt.Sprintf("Commenting on issue %v Comment: %v", strconv.Itoa(number), comment))
 	client := NewGithubClient()
 	_, _, err := client.Issues.CreateComment(repoOwner, repoName, number, &github.IssueComment{Body: &comment})
 	if err != nil {
-		LogError("Error: ", mlog.String("err", err.Error()))
+		mlog.Error(fmt.Sprintf("Error: %v", err.Error()))
 	}
-	LogInfo("Finished commenting")
+	mlog.Info("Finished commenting")
 }

--- a/server/issue.go
+++ b/server/issue.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-mattermod/model"
+	"github.com/mattermost/mattermost-server/mlog"
 )
 
 func handleIssueEvent(event *PullRequestEvent) {
@@ -16,7 +17,7 @@ func handleIssueEvent(event *PullRequestEvent) {
 
 	issue, err := GetIssueFromGithub(parts[len(parts)-2], parts[len(parts)-1], event.Issue)
 	if err != nil {
-		LogError(err.Error())
+		mlog.Error(err.Error())
 		return
 	}
 
@@ -26,11 +27,11 @@ func handleIssueEvent(event *PullRequestEvent) {
 func checkIssueForChanges(issue *model.Issue) {
 	var oldIssue *model.Issue
 	if result := <-Srv.Store.Issue().Get(issue.RepoOwner, issue.RepoName, issue.Number); result.Err != nil {
-		LogError(result.Err.Error())
+		mlog.Error(result.Err.Error())
 		return
 	} else if result.Data == nil {
 		if result := <-Srv.Store.Issue().Save(issue); result.Err != nil {
-			LogError(result.Err.Error())
+			mlog.Error(result.Err.Error())
 		}
 		return
 	} else {
@@ -50,17 +51,17 @@ func checkIssueForChanges(issue *model.Issue) {
 		}
 
 		if !hadLabel {
-			LogInfo(fmt.Sprintf("issue %v added label %v", issue.Number, label))
+			mlog.Info(fmt.Sprintf("issue %v added label %v", issue.Number, label))
 			handleIssueLabeled(issue, label)
 			hasChanges = true
 		}
 	}
 
 	if hasChanges {
-		LogInfo(fmt.Sprintf("issue %v has changes", issue.Number))
+		mlog.Info(fmt.Sprintf("issue %v has changes", issue.Number))
 
 		if result := <-Srv.Store.Issue().Save(issue); result.Err != nil {
-			LogError(result.Err.Error())
+			mlog.Error(result.Err.Error())
 			return
 		}
 	}
@@ -75,14 +76,14 @@ func handleIssueLabeled(issue *model.Issue, addedLabel string) {
 
 	comments, _, err := client.Issues.ListComments(issue.RepoOwner, issue.RepoName, issue.Number, nil)
 	if err != nil {
-		LogError(err.Error())
+		mlog.Error(err.Error())
 		return
 	}
 
 	for _, label := range Config.IssueLabels {
 		finalMessage := strings.Replace(label.Message, "USERNAME", issue.Username, -1)
 		if label.Label == addedLabel && !messageByUserContains(comments, Config.Username, finalMessage) {
-			LogInfo("Posted message for label: " + label.Label + " on PR: " + strconv.Itoa(issue.Number))
+			mlog.Info(fmt.Sprintf("Posted message for label: %v on PR: %v", label.Label, strconv.Itoa(issue.Number)))
 			commentOnIssue(issue.RepoOwner, issue.RepoName, issue.Number, finalMessage)
 		}
 	}

--- a/server/issue.go
+++ b/server/issue.go
@@ -4,8 +4,6 @@
 package server
 
 import (
-	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/mattermost/mattermost-mattermod/model"
@@ -51,14 +49,14 @@ func checkIssueForChanges(issue *model.Issue) {
 		}
 
 		if !hadLabel {
-			mlog.Info(fmt.Sprintf("issue %v added label %v", issue.Number, label))
+			mlog.Info("issue added label", mlog.Int("issue", issue.Number), mlog.String("label", label))
 			handleIssueLabeled(issue, label)
 			hasChanges = true
 		}
 	}
 
 	if hasChanges {
-		mlog.Info(fmt.Sprintf("issue %v has changes", issue.Number))
+		mlog.Info("issue has changes", mlog.Int("issue", issue.Number))
 
 		if result := <-Srv.Store.Issue().Save(issue); result.Err != nil {
 			mlog.Error(result.Err.Error())
@@ -83,7 +81,7 @@ func handleIssueLabeled(issue *model.Issue, addedLabel string) {
 	for _, label := range Config.IssueLabels {
 		finalMessage := strings.Replace(label.Message, "USERNAME", issue.Username, -1)
 		if label.Label == addedLabel && !messageByUserContains(comments, Config.Username, finalMessage) {
-			mlog.Info(fmt.Sprintf("Posted message for label: %v on PR: %v", label.Label, strconv.Itoa(issue.Number)))
+			mlog.Info("Posted message for label on PR", mlog.String("label", label.Label), mlog.Int("issue", issue.Number))
 			commentOnIssue(issue.RepoOwner, issue.RepoName, issue.Number, finalMessage)
 		}
 	}

--- a/server/issue.go
+++ b/server/issue.go
@@ -15,7 +15,7 @@ func handleIssueEvent(event *PullRequestEvent) {
 
 	issue, err := GetIssueFromGithub(parts[len(parts)-2], parts[len(parts)-1], event.Issue)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Error("issue_error", mlog.Err(err))
 		return
 	}
 
@@ -74,7 +74,7 @@ func handleIssueLabeled(issue *model.Issue, addedLabel string) {
 
 	comments, _, err := client.Issues.ListComments(issue.RepoOwner, issue.RepoName, issue.Number, nil)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Error("issue_error", mlog.Err(err))
 		return
 	}
 

--- a/server/log.go
+++ b/server/log.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/mattermost/mattermost-server/mlog"
 )
@@ -24,10 +23,5 @@ func LogErrorToMattermost(msg string, args ...interface{}) {
 		}
 	}
 
-	// Safely convert args into serializable fields
-	var builder strings.Builder
-	for _, arg := range args {
-		builder.WriteString(fmt.Sprintf("%v", arg))
-	}
-	mlog.Error(fmt.Sprintf("%v %v", msg, builder.String()))
+	mlog.Error(fmt.Sprintf(msg, args...))
 }

--- a/server/log.go
+++ b/server/log.go
@@ -19,7 +19,7 @@ func LogErrorToMattermost(msg string, args ...interface{}) {
 		webhookRequest := &WebhookRequest{Username: "Mattermod", Text: webhookMessage}
 
 		if err := sendToWebhook(webhookRequest, Config.MattermostWebhookURL); err != nil {
-			mlog.Error("Unable to post to Mattermost webhook", mlog.String("webhookerror", err.Error()))
+			mlog.Error("Unable to post to Mattermost webhook", mlog.Err(err))
 		}
 	}
 

--- a/server/log.go
+++ b/server/log.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strings"
 
-	l4g "github.com/alecthomas/log4go"
 	"github.com/google/go-github/github"
+	"github.com/mattermost/mattermost-server/mlog"
 )
 
 func LogLabels(prNumber int, labels []github.Label) {
@@ -20,21 +20,21 @@ func LogLabels(prNumber int, labels []github.Label) {
 		labelStrings[i] = "`" + *label.Name + "`"
 	}
 
-	l4g.Debug("PR %d has labels: %v", prNumber, strings.Join(labelStrings, ", "))
+	mlog.Debug("PR %d has labels: %v", prNumber, strings.Join(labelStrings, ", "))
 }
 
 func LogInfo(msg string, args ...interface{}) {
-	l4g.Info(msg, args...)
+	mlog.Info(msg, args...)
 	Log("INFO", msg, args...)
 }
 
 func LogError(msg string, args ...interface{}) {
-	l4g.Error(msg, args...)
+	mlog.Error(msg, args...)
 	Log("ERROR", msg, args...)
 }
 
 func LogCritical(msg string, args ...interface{}) {
-	l4g.Critical(msg, args...)
+	mlog.Critical(msg, args...)
 	Log("CRIT", msg, args...)
 	panic(fmt.Sprintf(msg, args...))
 }

--- a/server/log.go
+++ b/server/log.go
@@ -23,19 +23,16 @@ func LogLabels(prNumber int, labels []github.Label) {
 	mlog.Debug(fmt.Sprintf("PR %d has labels: %v", prNumber, strings.Join(labelStrings, ", ")))
 }
 
-func LogInfo(msg string, args ...interface{}) {
+func LogInfo(msg string, args ...mlog.Field) {
 	mlog.Info(msg, args...)
-	Log("INFO", msg, args...)
 }
 
-func LogError(msg string, args ...interface{}) {
+func LogError(msg string, args ...mlog.Field) {
 	mlog.Error(msg, args...)
-	Log("ERROR", msg, args...)
 }
 
-func LogCritical(msg string, args ...interface{}) {
+func LogCritical(msg string, args ...mlog.Field) {
 	mlog.Critical(msg, args...)
-	Log("CRIT", msg, args...)
 	panic(fmt.Sprintf(msg, args...))
 }
 
@@ -62,7 +59,7 @@ func LogErrorToMattermost(msg string, args ...interface{}) {
 		webhookRequest := &WebhookRequest{Username: "Mattermod", Text: webhookMessage}
 
 		if err := sendToWebhook(webhookRequest, Config.MattermostWebhookURL); err != nil {
-			LogError("Unable to post to Mattermost webhook: %v", err)
+			LogError(fmt.Sprintf("Unable to post to Mattermost webhook: %v", err), mlog.String("err", err.Error()))
 		}
 	}
 

--- a/server/log.go
+++ b/server/log.go
@@ -20,7 +20,7 @@ func LogLabels(prNumber int, labels []github.Label) {
 		labelStrings[i] = "`" + *label.Name + "`"
 	}
 
-	mlog.Debug("PR %d has labels: %v", prNumber, strings.Join(labelStrings, ", "))
+	mlog.Debug(fmt.Sprintf("PR %d has labels: %v", prNumber, strings.Join(labelStrings, ", ")))
 }
 
 func LogInfo(msg string, args ...interface{}) {

--- a/server/log.go
+++ b/server/log.go
@@ -19,7 +19,7 @@ func LogErrorToMattermost(msg string, args ...interface{}) {
 		webhookRequest := &WebhookRequest{Username: "Mattermod", Text: webhookMessage}
 
 		if err := sendToWebhook(webhookRequest, Config.MattermostWebhookURL); err != nil {
-			mlog.Error(fmt.Sprintf("Unable to post to Mattermost webhook: %v", err.Error()))
+			mlog.Error("Unable to post to Mattermost webhook", mlog.String("webhookerror", err.Error()))
 		}
 	}
 

--- a/server/log.go
+++ b/server/log.go
@@ -5,24 +5,9 @@ package server
 
 import (
 	"fmt"
-	"log"
-	"os"
 
 	"github.com/mattermost/mattermost-server/mlog"
 )
-
-func Log(level string, msg string, args ...interface{}) {
-	log.Printf("%v %v\n", level, fmt.Sprintf(msg, args...))
-	f, err := os.OpenFile("mattermod.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if err != nil {
-		log.Printf("Failed to write to file")
-		return
-	}
-	defer f.Close()
-
-	log.SetOutput(f)
-	log.Printf("%v %v\n", level, fmt.Sprintf(msg, args...))
-}
 
 func LogErrorToMattermost(msg string, args ...interface{}) {
 	if Config.MattermostWebhookURL != "" {
@@ -38,5 +23,5 @@ func LogErrorToMattermost(msg string, args ...interface{}) {
 		}
 	}
 
-	mlog.Error(msg, args...)
+	//mlog.Error(msg, args...)
 }

--- a/server/log.go
+++ b/server/log.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mattermost/mattermost-server/mlog"
 )
@@ -23,5 +24,10 @@ func LogErrorToMattermost(msg string, args ...interface{}) {
 		}
 	}
 
-	//mlog.Error(msg, args...)
+	// Safely convert args into serializable fields
+	var builder strings.Builder
+	for _, arg := range args {
+		builder.WriteString(fmt.Sprintf("%v", arg))
+	}
+	mlog.Error(fmt.Sprintf("%v %v", msg, builder.String()))
 }

--- a/server/log.go
+++ b/server/log.go
@@ -7,34 +7,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
-	"github.com/google/go-github/github"
 	"github.com/mattermost/mattermost-server/mlog"
 )
-
-func LogLabels(prNumber int, labels []github.Label) {
-	labelStrings := make([]string, len(labels))
-
-	for i, label := range labels {
-		labelStrings[i] = "`" + *label.Name + "`"
-	}
-
-	mlog.Debug(fmt.Sprintf("PR %d has labels: %v", prNumber, strings.Join(labelStrings, ", ")))
-}
-
-func LogInfo(msg string, args ...mlog.Field) {
-	mlog.Info(msg, args...)
-}
-
-func LogError(msg string, args ...mlog.Field) {
-	mlog.Error(msg, args...)
-}
-
-func LogCritical(msg string, args ...mlog.Field) {
-	mlog.Critical(msg, args...)
-	panic(fmt.Sprintf(msg, args...))
-}
 
 func Log(level string, msg string, args ...interface{}) {
 	log.Printf("%v %v\n", level, fmt.Sprintf(msg, args...))
@@ -59,9 +34,9 @@ func LogErrorToMattermost(msg string, args ...interface{}) {
 		webhookRequest := &WebhookRequest{Username: "Mattermod", Text: webhookMessage}
 
 		if err := sendToWebhook(webhookRequest, Config.MattermostWebhookURL); err != nil {
-			LogError(fmt.Sprintf("Unable to post to Mattermost webhook: %v", err), mlog.String("err", err.Error()))
+			mlog.Error(fmt.Sprintf("Unable to post to Mattermost webhook: %v", err.Error()))
 		}
 	}
 
-	LogError(msg, args...)
+	mlog.Error(msg, args...)
 }

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -30,7 +30,7 @@ func handlePullRequestEvent(event *PullRequestEvent) {
 			mlog.Info(fmt.Sprintf("Nothing to do. There is not Spinmint for this PR %v", pr.Number))
 		} else {
 			spinmint := result.Data.(*model.Spinmint)
-			mlog.Info(fmt.Sprintf("Spinmint instance %v", spinmint.InstanceId), mlog.String("err", result.Err.Error()))
+			mlog.Info(fmt.Sprintf("Spinmint instance %v", spinmint.InstanceId))
 			mlog.Info("Will destroy the spinmint for a merged/closed PR.")
 
 			commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.DestroyedSpinmintMessage)
@@ -125,14 +125,14 @@ func handlePROpened(pr *model.PullRequest) {
 
 	resp, err := http.Get(Config.SignedCLAURL)
 	if err != nil {
-		mlog.Error("Unable to get CLA list: " + err.Error())
+		mlog.Error(fmt.Sprintf("Unable to get CLA list: %v", err.Error()))
 		return
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		mlog.Error("Unable to read response body: " + err.Error())
+		mlog.Error(fmt.Sprintf("Unable to read response body: %v", err.Error()))
 		return
 	}
 
@@ -174,10 +174,10 @@ func handlePRLabeled(pr *model.PullRequest, addedLabel string) {
 		mlog.Info("looking for other labels")
 
 		for _, label := range Config.PrLabels {
-			mlog.Info("looking for " + label.Label)
+			mlog.Info(fmt.Sprintf("looking for %v", label.Label))
 			finalMessage := strings.Replace(label.Message, "USERNAME", pr.Username, -1)
 			if label.Label == addedLabel && !messageByUserContains(comments, Config.Username, finalMessage) {
-				mlog.Info("Posted message for label: " + label.Label + " on PR: " + strconv.Itoa(pr.Number))
+				mlog.Info(fmt.Sprintf("Posted message for label: %v on PR: ", label.Label, strconv.Itoa(pr.Number)))
 				commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, finalMessage)
 			}
 		}

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -27,10 +27,10 @@ func handlePullRequestEvent(event *PullRequestEvent) {
 		if result := <-Srv.Store.Spinmint().Get(pr.Number); result.Err != nil {
 			LogError(fmt.Sprintf("Unable to get the spinmint information: %v. Maybe does not exist.", result.Err.Error()), mlog.String("err", result.Err.Error()))
 		} else if result.Data == nil {
-			LogInfo("Nothing to do. There is not Spinmint for this PR %v", pr.Number)
+			LogInfo(fmt.Sprintf("Nothing to do. There is not Spinmint for this PR %v", pr.Number), mlog.Int("pr", pr.Number))
 		} else {
 			spinmint := result.Data.(*model.Spinmint)
-			LogInfo("Spinmint instance %v", spinmint.InstanceId)
+			LogInfo(fmt.Sprintf("Spinmint instance %v", spinmint.InstanceId), mlog.String("err", result.Err.Error()))
 			LogInfo("Will destroy the spinmint for a merged/closed PR.")
 
 			commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.DestroyedSpinmintMessage)

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-mattermod/model"
+	"github.com/mattermost/mattermost-server/mlog"
 )
 
 func handlePullRequestEvent(event *PullRequestEvent) {
@@ -24,7 +25,7 @@ func handlePullRequestEvent(event *PullRequestEvent) {
 
 	if event.Action == "closed" {
 		if result := <-Srv.Store.Spinmint().Get(pr.Number); result.Err != nil {
-			LogError("Unable to get the spinmint information: %v. Maybe does not exist.", result.Err.Error())
+			LogError(fmt.Sprintf("Unable to get the spinmint information: %v. Maybe does not exist.", result.Err.Error()), mlog.String("err", result.Err.Error()))
 		} else if result.Data == nil {
 			LogInfo("Nothing to do. There is not Spinmint for this PR %v", pr.Number)
 		} else {

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -24,7 +23,7 @@ func handlePullRequestEvent(event *PullRequestEvent) {
 
 	if event.Action == "closed" {
 		if result := <-Srv.Store.Spinmint().Get(pr.Number); result.Err != nil {
-			mlog.Error(fmt.Sprintf("Unable to get the spinmint information: %v. Maybe does not exist.", result.Err.Error()))
+			mlog.Error("Unable to get the spinmint information: Maybe does not exist.", mlog.String("prerror", result.Err.Error()))
 		} else if result.Data == nil {
 			mlog.Info("Nothing to do. There is not Spinmint for this PR", mlog.Int("pr", pr.Number))
 		} else {
@@ -124,14 +123,14 @@ func handlePROpened(pr *model.PullRequest) {
 
 	resp, err := http.Get(Config.SignedCLAURL)
 	if err != nil {
-		mlog.Error(fmt.Sprintf("Unable to get CLA list: %v", err.Error()))
+		mlog.Error("Unable to get CLA list", mlog.String("claerror", err.Error()))
 		return
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		mlog.Error(fmt.Sprintf("Unable to read response body: %v", err.Error()))
+		mlog.Error("Unable to read response body", mlog.String("responseerror", err.Error()))
 		return
 	}
 
@@ -149,7 +148,7 @@ func handlePRLabeled(pr *model.PullRequest, addedLabel string) {
 
 	comments, _, err := NewGithubClient().Issues.ListComments(pr.RepoOwner, pr.RepoName, pr.Number, nil)
 	if err != nil {
-		mlog.Error(fmt.Sprintf("Unable to list comments for PR %v: %v", pr.Number, err.Error()))
+		mlog.Error("Unable to list comments for PR", mlog.Int("pr", pr.Number), mlog.String("prerror", err.Error()))
 		return
 	}
 

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -17,7 +17,7 @@ import (
 func handlePullRequestEvent(event *PullRequestEvent) {
 	pr, err := GetPullRequestFromGithub(event.PullRequest)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Error("pr_error", mlog.Err(err))
 		return
 	}
 
@@ -123,14 +123,14 @@ func handlePROpened(pr *model.PullRequest) {
 
 	resp, err := http.Get(Config.SignedCLAURL)
 	if err != nil {
-		mlog.Error("Unable to get CLA list", mlog.String("cla_error", err.Error()))
+		mlog.Error("Unable to get CLA list", mlog.Err(err))
 		return
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		mlog.Error("Unable to read response body", mlog.String("responseerror", err.Error()))
+		mlog.Error("Unable to read response body", mlog.Err(err))
 		return
 	}
 
@@ -148,7 +148,7 @@ func handlePRLabeled(pr *model.PullRequest, addedLabel string) {
 
 	comments, _, err := NewGithubClient().Issues.ListComments(pr.RepoOwner, pr.RepoName, pr.Number, nil)
 	if err != nil {
-		mlog.Error("Unable to list comments for PR", mlog.Int("pr", pr.Number), mlog.String("pr_error", err.Error()))
+		mlog.Error("Unable to list comments for PR", mlog.Int("pr", pr.Number), mlog.Err(err))
 		return
 	}
 
@@ -195,7 +195,7 @@ func handlePRUnlabeled(pr *model.PullRequest, removedLabel string) {
 
 	comments, _, err := NewGithubClient().Issues.ListComments(pr.RepoOwner, pr.RepoName, pr.Number, nil)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Error("pr_error", mlog.Err(err))
 		return
 	}
 

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -23,7 +23,7 @@ func handlePullRequestEvent(event *PullRequestEvent) {
 
 	if event.Action == "closed" {
 		if result := <-Srv.Store.Spinmint().Get(pr.Number); result.Err != nil {
-			mlog.Error("Unable to get the spinmint information: Maybe does not exist.", mlog.String("prerror", result.Err.Error()))
+			mlog.Error("Unable to get the spinmint information: Maybe does not exist.", mlog.String("pr_error", result.Err.Error()))
 		} else if result.Data == nil {
 			mlog.Info("Nothing to do. There is not Spinmint for this PR", mlog.Int("pr", pr.Number))
 		} else {
@@ -123,7 +123,7 @@ func handlePROpened(pr *model.PullRequest) {
 
 	resp, err := http.Get(Config.SignedCLAURL)
 	if err != nil {
-		mlog.Error("Unable to get CLA list", mlog.String("claerror", err.Error()))
+		mlog.Error("Unable to get CLA list", mlog.String("cla_error", err.Error()))
 		return
 	}
 
@@ -148,7 +148,7 @@ func handlePRLabeled(pr *model.PullRequest, addedLabel string) {
 
 	comments, _, err := NewGithubClient().Issues.ListComments(pr.RepoOwner, pr.RepoName, pr.Number, nil)
 	if err != nil {
-		mlog.Error("Unable to list comments for PR", mlog.Int("pr", pr.Number), mlog.String("prerror", err.Error()))
+		mlog.Error("Unable to list comments for PR", mlog.Int("pr", pr.Number), mlog.String("pr_error", err.Error()))
 		return
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -65,6 +65,9 @@ func Start() {
 	}
 	Srv.Log = mlog.NewLogger(logConfig)
 
+	mlog.RedirectStdLog(Srv.Log)
+	mlog.InitGlobalLogger(Srv.Log)
+
 	var handler http.Handler = Srv.Router
 	go func() {
 		LogInfo("Listening on " + Config.ListenAddress)
@@ -217,7 +220,6 @@ func listSpinmints(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// GetLogFileLocation was borrowed from Mattermost server
 func GetLogFileLocation(fileLocation string) string {
 	if fileLocation == "" {
 		fileLocation, _ = fileutils.FindDir("logs")

--- a/server/server.go
+++ b/server/server.go
@@ -56,7 +56,7 @@ func Start() {
 
 	var handler http.Handler = Srv.Router
 	go func() {
-		mlog.Info(fmt.Sprintf("Listening on %v", Config.ListenAddress))
+		mlog.Info("Listening on", mlog.String("address", Config.ListenAddress))
 		err := manners.ListenAndServe(Config.ListenAddress, handler)
 		if err != nil {
 			LogErrorToMattermost(err.Error())
@@ -136,7 +136,7 @@ func prEvent(w http.ResponseWriter, r *http.Request) {
 	event := PullRequestEventFromJson(ioutil.NopCloser(bytes.NewBuffer(buf)))
 
 	if event.PRNumber != 0 {
-		mlog.Info(fmt.Sprintf("pr event %v %v", event.PRNumber, event.Action))
+		mlog.Info("pr event", mlog.Int("pr", event.PRNumber), mlog.String("action", event.Action))
 		handlePullRequestEvent(event)
 	} else {
 		handleIssueEvent(event)

--- a/server/server.go
+++ b/server/server.go
@@ -26,7 +26,6 @@ import (
 type Server struct {
 	Store  store.Store
 	Router *mux.Router
-	Log    *mlog.Logger
 }
 
 const (
@@ -45,30 +44,13 @@ var (
 )
 
 func Start() {
-	// Setup logging before creating the server and the server creation can
-	// and will generate errors if something bad happens.
-	loggingConfig := &mlog.LoggerConfiguration{
-		EnableConsole: Config.LogSettings.EnableConsole,
-		ConsoleJson:   Config.LogSettings.ConsoleJson,
-		ConsoleLevel:  strings.ToLower(Config.LogSettings.ConsoleLevel),
-		EnableFile:    Config.LogSettings.EnableFile,
-		FileJson:      Config.LogSettings.FileJson,
-		FileLevel:     strings.ToLower(Config.LogSettings.FileLevel),
-		FileLocation:  GetLogFileLocation(Config.LogSettings.FileLocation),
-	}
-
-	logger := mlog.NewLogger(loggingConfig)
-	mlog.RedirectStdLog(logger)
-	mlog.InitGlobalLogger(logger)
-
+	SetupLogging()
 	mlog.Info("Starting pr manager")
 
 	Srv = &Server{
 		Store:  store.NewSqlStore(Config.DriverName, Config.DataSource),
 		Router: mux.NewRouter(),
 	}
-
-	Srv.Log = logger
 
 	addApis(Srv.Router)
 
@@ -231,4 +213,21 @@ func GetLogFileLocation(fileLocation string) string {
 	}
 
 	return filepath.Join(fileLocation, LOG_FILENAME)
+}
+
+func SetupLogging() {
+	// and will generate errors if something bad happens.
+	loggingConfig := &mlog.LoggerConfiguration{
+		EnableConsole: Config.LogSettings.EnableConsole,
+		ConsoleJson:   Config.LogSettings.ConsoleJson,
+		ConsoleLevel:  strings.ToLower(Config.LogSettings.ConsoleLevel),
+		EnableFile:    Config.LogSettings.EnableFile,
+		FileJson:      Config.LogSettings.FileJson,
+		FileLevel:     strings.ToLower(Config.LogSettings.FileLevel),
+		FileLocation:  GetLogFileLocation(Config.LogSettings.FileLocation),
+	}
+
+	logger := mlog.NewLogger(loggingConfig)
+	mlog.RedirectStdLog(logger)
+	mlog.InitGlobalLogger(logger)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -75,7 +75,7 @@ func Tick() {
 			State: "open",
 		})
 		if err != nil {
-			mlog.Error("failed to get PRs", mlog.String("repoowner", repository.Owner), mlog.String("reponame", repository.Name))
+			mlog.Error("failed to get PRs", mlog.String("repo_owner", repository.Owner), mlog.String("repo_name", repository.Name))
 			mlog.Error(err.Error())
 			continue
 		}
@@ -83,7 +83,7 @@ func Tick() {
 		for _, ghPullRequest := range ghPullRequests {
 			pullRequest, err := GetPullRequestFromGithub(ghPullRequest)
 			if err != nil {
-				mlog.Error("failed to convert PR", mlog.Int("pr", *ghPullRequest.Number), mlog.String("prerror", err.Error()))
+				mlog.Error("failed to convert PR", mlog.Int("pr", *ghPullRequest.Number), mlog.String("pr_error", err.Error()))
 				continue
 			}
 
@@ -94,7 +94,7 @@ func Tick() {
 			State: "open",
 		})
 		if err != nil {
-			mlog.Error("failed to get issues", mlog.String("repoowner", repository.Owner), mlog.String("reponame", repository.Name))
+			mlog.Error("failed to get issues", mlog.String("repo_owner", repository.Owner), mlog.String("repo_name", repository.Name))
 			mlog.Error(err.Error())
 			continue
 		}
@@ -107,7 +107,7 @@ func Tick() {
 
 			issue, err := GetIssueFromGithub(repository.Owner, repository.Name, ghIssue)
 			if err != nil {
-				mlog.Error("failed to convert issue", mlog.Int("issue", *ghIssue.Number), mlog.String("issueerror", err.Error()))
+				mlog.Error("failed to convert issue", mlog.Int("issue", *ghIssue.Number), mlog.String("issue_error", err.Error()))
 				continue
 			}
 

--- a/server/server.go
+++ b/server/server.go
@@ -216,7 +216,6 @@ func GetLogFileLocation(fileLocation string) string {
 }
 
 func SetupLogging() {
-	// and will generate errors if something bad happens.
 	loggingConfig := &mlog.LoggerConfiguration{
 		EnableConsole: Config.LogSettings.EnableConsole,
 		ConsoleJson:   Config.LogSettings.ConsoleJson,

--- a/server/server.go
+++ b/server/server.go
@@ -45,6 +45,22 @@ var (
 )
 
 func Start() {
+	// Setup logging before creating the server and the server creation can
+	// and will generate errors if something bad happens.
+	loggingConfig := &mlog.LoggerConfiguration{
+		EnableConsole: Config.LogSettings.EnableConsole,
+		ConsoleJson:   Config.LogSettings.ConsoleJson,
+		ConsoleLevel:  strings.ToLower(Config.LogSettings.ConsoleLevel),
+		EnableFile:    Config.LogSettings.EnableFile,
+		FileJson:      Config.LogSettings.FileJson,
+		FileLevel:     strings.ToLower(Config.LogSettings.FileLevel),
+		FileLocation:  GetLogFileLocation(Config.LogSettings.FileLocation),
+	}
+
+	logger := mlog.NewLogger(loggingConfig)
+	mlog.RedirectStdLog(logger)
+	mlog.InitGlobalLogger(logger)
+
 	mlog.Info("Starting pr manager")
 
 	Srv = &Server{
@@ -52,21 +68,9 @@ func Start() {
 		Router: mux.NewRouter(),
 	}
 
+	Srv.Log = logger
+
 	addApis(Srv.Router)
-
-	logConfig := &mlog.LoggerConfiguration{
-		EnableConsole: Config.LoggerConfiguration.EnableConsole,
-		ConsoleJson:   Config.LoggerConfiguration.ConsoleJson,
-		ConsoleLevel:  strings.ToLower(Config.LoggerConfiguration.ConsoleLevel),
-		EnableFile:    Config.LoggerConfiguration.EnableFile,
-		FileJson:      Config.LoggerConfiguration.FileJson,
-		FileLevel:     strings.ToLower(Config.LoggerConfiguration.FileLevel),
-		FileLocation:  GetLogFileLocation(Config.LoggerConfiguration.FileLocation),
-	}
-	Srv.Log = mlog.NewLogger(logConfig)
-
-	mlog.RedirectStdLog(Srv.Log)
-	mlog.InitGlobalLogger(Srv.Log)
 
 	var handler http.Handler = Srv.Router
 	go func() {

--- a/server/server.go
+++ b/server/server.go
@@ -75,6 +75,7 @@ func Start() {
 		if err != nil {
 			LogErrorToMattermost(err.Error())
 			mlog.Critical(err.Error())
+			panic(err.Error())
 		}
 	}()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -59,7 +59,7 @@ func Start() {
 		err := manners.ListenAndServe(Config.ListenAddress, handler)
 		if err != nil {
 			LogErrorToMattermost(err.Error())
-			mlog.Critical(err.Error())
+			mlog.Critical("server_error", mlog.Err(err))
 			panic(err.Error())
 		}
 	}()
@@ -76,14 +76,14 @@ func Tick() {
 		})
 		if err != nil {
 			mlog.Error("failed to get PRs", mlog.String("repo_owner", repository.Owner), mlog.String("repo_name", repository.Name))
-			mlog.Error(err.Error())
+			mlog.Error("pr_error", mlog.Err(err))
 			continue
 		}
 
 		for _, ghPullRequest := range ghPullRequests {
 			pullRequest, err := GetPullRequestFromGithub(ghPullRequest)
 			if err != nil {
-				mlog.Error("failed to convert PR", mlog.Int("pr", *ghPullRequest.Number), mlog.String("pr_error", err.Error()))
+				mlog.Error("failed to convert PR", mlog.Int("pr", *ghPullRequest.Number), mlog.Err(err))
 				continue
 			}
 
@@ -95,7 +95,7 @@ func Tick() {
 		})
 		if err != nil {
 			mlog.Error("failed to get issues", mlog.String("repo_owner", repository.Owner), mlog.String("repo_name", repository.Name))
-			mlog.Error(err.Error())
+			mlog.Error("issue_error", mlog.Err(err))
 			continue
 		}
 
@@ -107,7 +107,7 @@ func Tick() {
 
 			issue, err := GetIssueFromGithub(repository.Owner, repository.Name, ghIssue)
 			if err != nil {
-				mlog.Error("failed to convert issue", mlog.Int("issue", *ghIssue.Number), mlog.String("issue_error", err.Error()))
+				mlog.Error("failed to convert issue", mlog.Int("issue", *ghIssue.Number), mlog.Err(err))
 				continue
 			}
 
@@ -163,7 +163,7 @@ func listPrs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if b, err := json.Marshal(prs); err != nil {
-		mlog.Error(err.Error())
+		mlog.Error("pr_error", mlog.Err(err))
 		w.WriteHeader(http.StatusInternalServerError)
 	} else {
 		w.Write(b)
@@ -181,7 +181,7 @@ func listIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if b, err := json.Marshal(issues); err != nil {
-		mlog.Error(err.Error())
+		mlog.Error("issue_error", mlog.Err(err))
 		w.WriteHeader(http.StatusInternalServerError)
 	} else {
 		w.Write(b)
@@ -199,7 +199,7 @@ func listSpinmints(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if b, err := json.Marshal(spinmints); err != nil {
-		mlog.Error(err.Error())
+		mlog.Error("spinmint_error", mlog.Err(err))
 		w.WriteHeader(http.StatusInternalServerError)
 	} else {
 		w.Write(b)

--- a/server/server.go
+++ b/server/server.go
@@ -70,7 +70,7 @@ func Start() {
 
 	var handler http.Handler = Srv.Router
 	go func() {
-		mlog.Info("Listening on " + Config.ListenAddress)
+		mlog.Info(fmt.Sprintf("Listening on %v", Config.ListenAddress))
 		err := manners.ListenAndServe(Config.ListenAddress, handler)
 		if err != nil {
 			LogErrorToMattermost(err.Error())

--- a/server/server.go
+++ b/server/server.go
@@ -6,7 +6,6 @@ package server
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -76,7 +75,7 @@ func Tick() {
 			State: "open",
 		})
 		if err != nil {
-			mlog.Error(fmt.Sprintf("failed to get prs %v/%v", repository.Owner, repository.Name))
+			mlog.Error("failed to get PRs", mlog.String("repoowner", repository.Owner), mlog.String("reponame", repository.Name))
 			mlog.Error(err.Error())
 			continue
 		}
@@ -84,7 +83,7 @@ func Tick() {
 		for _, ghPullRequest := range ghPullRequests {
 			pullRequest, err := GetPullRequestFromGithub(ghPullRequest)
 			if err != nil {
-				mlog.Error(fmt.Sprintf("failed to convert PR for %v: %v", ghPullRequest.Number, err.Error()))
+				mlog.Error("failed to convert PR", mlog.Int("pr", *ghPullRequest.Number), mlog.String("prerror", err.Error()))
 				continue
 			}
 
@@ -95,7 +94,7 @@ func Tick() {
 			State: "open",
 		})
 		if err != nil {
-			mlog.Error(fmt.Sprintf("failed to get issues %v/%v", repository.Owner, repository.Name))
+			mlog.Error("failed to get issues", mlog.String("repoowner", repository.Owner), mlog.String("reponame", repository.Name))
 			mlog.Error(err.Error())
 			continue
 		}
@@ -108,7 +107,7 @@ func Tick() {
 
 			issue, err := GetIssueFromGithub(repository.Owner, repository.Name, ghIssue)
 			if err != nil {
-				mlog.Error(fmt.Sprintf("failed to convert issue for %v: %v", ghIssue.Number, err.Error()))
+				mlog.Error("failed to convert issue", mlog.Int("issue", *ghIssue.Number), mlog.String("issueerror", err.Error()))
 				continue
 			}
 

--- a/server/spinmint.go
+++ b/server/spinmint.go
@@ -224,7 +224,7 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 	jobName := fmt.Sprintf("mm/job/%s", repo.JobName)
 	job, err := client.GetJob(jobName)
 	if err != nil {
-		mlog.Error("Failed to get Jenkins job", mlog.String("job", jobName), mlog.String("jenkins_error", err.Error()))
+		mlog.Error("Failed to get Jenkins job", mlog.String("job", jobName), mlog.Err(err))
 		return
 	}
 
@@ -233,7 +233,7 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 	parameters.Add("PR_NUMBER", strconv.Itoa(pr.Number))
 	err = client.Build(jobName, parameters)
 	if err != nil {
-		mlog.Error("Failed to build Jenkins job", mlog.String("job", jobName), mlog.String("jenkins_error", err.Error()))
+		mlog.Error("Failed to build Jenkins job", mlog.String("job", jobName), mlog.Err(err))
 		return
 	}
 
@@ -241,7 +241,7 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 	for {
 		build, err := client.GetLastBuild(job)
 		if err != nil {
-			mlog.Error("Failed to get the build Jenkins job", mlog.String("job", jobName), mlog.String("jenkins_error", err.Error()))
+			mlog.Error("Failed to get the build Jenkins job", mlog.String("job", jobName), mlog.Err(err))
 			return
 		}
 		if !build.Building && build.Result == "SUCCESS" {
@@ -310,7 +310,7 @@ func waitForBuild(client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRe
 
 			job, err := client.GetJob(jobName)
 			if err != nil {
-				mlog.Error("Failed to get Jenkins job", mlog.String("job", jobName), mlog.String("jenkins_error", err.Error()))
+				mlog.Error("Failed to get Jenkins job", mlog.String("job", jobName), mlog.Err(err))
 				return pr, false
 			}
 
@@ -416,14 +416,14 @@ func destroySpinmint(pr *model.PullRequest, instanceId string) {
 
 	_, err := svc.TerminateInstances(params)
 	if err != nil {
-		mlog.Error("Error terminating instances", mlog.String("instanceerror", err.Error()))
+		mlog.Error("Error terminating instances", mlog.Err(err))
 		return
 	}
 
 	// Remove route53 entry
 	err = updateRoute53Subdomain(instanceId, "", "DELETE")
 	if err != nil {
-		mlog.Error("Error removing the Route53 entry", mlog.String("route53error", err.Error()))
+		mlog.Error("Error removing the Route53 entry", mlog.Err(err))
 		return
 	}
 
@@ -440,7 +440,7 @@ func getPublicDnsName(instance string) string {
 	}
 	resp, err := svc.DescribeInstances(params)
 	if err != nil {
-		mlog.Error("Problem getting instance ip", mlog.String("instanceerror", err.Error()))
+		mlog.Error("Problem getting instance ip", mlog.Err(err))
 		return ""
 	}
 

--- a/server/spinmint.go
+++ b/server/spinmint.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	jenkins "github.com/cpanato/golang-jenkins"
 	"github.com/mattermost/mattermost-mattermod/model"
+	"github.com/mattermost/mattermost-server/mlog"
 	// "github.com/mattermost/mattermost-load-test/ltops"
 	// "github.com/mattermost/mattermost-load-test/ltparse"
 	// "github.com/mattermost/mattermost-load-test/terraform"
@@ -120,14 +121,14 @@ func waitForBuildAndSetupLoadtest(pr *model.PullRequest) {
 func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 	repo, ok := Config.GetRepository(pr.RepoOwner, pr.RepoName)
 	if !ok || repo.JenkinsServer == "" {
-		LogError("Unable to set up spintmint for PR %v in %v/%v without Jenkins configured for server", pr.Number, pr.RepoOwner, pr.RepoName)
+		mlog.Error(fmt.Sprintf("Unable to set up spintmint for PR %v in %v/%v without Jenkins configured for server", pr.Number, pr.RepoOwner, pr.RepoName))
 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.SetupSpinmintFailedMessage)
 		return
 	}
 
 	credentials, ok := Config.JenkinsCredentials[repo.JenkinsServer]
 	if !ok {
-		LogError("No Jenkins credentials for server %v required for PR %v in %v/%v", repo.JenkinsServer, pr.Number, pr.RepoOwner, pr.RepoName)
+		mlog.Error(fmt.Sprintf("No Jenkins credentials for server %v required for PR %v in %v/%v", repo.JenkinsServer, pr.Number, pr.RepoOwner, pr.RepoName))
 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.SetupSpinmintFailedMessage)
 		return
 	}
@@ -137,7 +138,7 @@ func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 		ApiToken: credentials.ApiToken,
 	}, credentials.URL)
 
-	LogInfo("Waiting for Jenkins to build to set up spinmint for PR %v in %v/%v", pr.Number, pr.RepoOwner, pr.RepoName)
+	mlog.Info(fmt.Sprintf("Waiting for Jenkins to build to set up spinmint for PR %v in %v/%v", pr.Number, pr.RepoOwner, pr.RepoName))
 
 	pr, errr := waitForBuild(client, pr)
 	if errr == false || pr == nil {
@@ -152,7 +153,7 @@ func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 		return
 	}
 
-	LogInfo("Waiting for instance to come up.")
+	mlog.Info("Waiting for instance to come up.")
 	time.Sleep(time.Minute * 2)
 	publicdns := getPublicDnsName(*instance.InstanceId)
 
@@ -194,14 +195,14 @@ func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 func waitForMobileAppsBuild(pr *model.PullRequest) {
 	repo, ok := Config.GetRepository(pr.RepoOwner, pr.RepoName)
 	if !ok || repo.JenkinsServer == "" {
-		LogError("Unable to build the mobile app for PR %v in %v/%v without Jenkins configured for server", pr.Number, pr.RepoOwner, pr.RepoName)
+		mlog.Error(fmt.Sprintf("Unable to build the mobile app for PR %v in %v/%v without Jenkins configured for server", pr.Number, pr.RepoOwner, pr.RepoName))
 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.BuildMobileAppFailedMessage)
 		return
 	}
 
 	credentials, ok := Config.JenkinsCredentials[repo.JenkinsServer]
 	if !ok {
-		LogError("No Jenkins credentials for server %v required for PR %v in %v/%v", repo.JenkinsServer, pr.Number, pr.RepoOwner, pr.RepoName)
+		mlog.Error(fmt.Sprintf("No Jenkins credentials for server %v required for PR %v in %v/%v", repo.JenkinsServer, pr.Number, pr.RepoOwner, pr.RepoName))
 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.BuildMobileAppFailedMessage)
 		return
 	}
@@ -211,7 +212,7 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 		ApiToken: credentials.ApiToken,
 	}, credentials.URL)
 
-	LogInfo("Waiting for Jenkins to build to start build the mobile app for PR %v in %v/%v", pr.Number, pr.RepoOwner, pr.RepoName)
+	mlog.Info(fmt.Sprintf("Waiting for Jenkins to build to start build the mobile app for PR %v in %v/%v", pr.Number, pr.RepoOwner, pr.RepoName))
 
 	pr, errr := waitForBuild(client, pr)
 	if errr == false || pr == nil {
@@ -223,16 +224,16 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 	jobName := fmt.Sprintf("mm/job/%s", repo.JobName)
 	job, err := client.GetJob(jobName)
 	if err != nil {
-		LogError("Failed to get Jenkins job %v: %v", jobName, err)
+		mlog.Error(fmt.Sprintf("Failed to get Jenkins job %v: %v", jobName, err))
 		return
 	}
 
-	LogInfo("Will start the job %v", jobName)
+	mlog.Info(fmt.Sprintf("Will start the job %v", jobName))
 	parameters := url.Values{}
 	parameters.Add("PR_NUMBER", strconv.Itoa(pr.Number))
 	err = client.Build(jobName, parameters)
 	if err != nil {
-		LogError("Failed to build Jenkins job %v: %v", jobName, err)
+		mlog.Error(fmt.Sprintf("Failed to build Jenkins job %v: %v", jobName, err))
 		return
 	}
 
@@ -240,18 +241,18 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 	for {
 		build, err := client.GetLastBuild(job)
 		if err != nil {
-			LogError("Failed to get the build Jenkins job %v: %v", jobName, err)
+			mlog.Error(fmt.Sprintf("Failed to get the build Jenkins job %v: %v", jobName, err))
 			return
 		}
 		if !build.Building && build.Result == "SUCCESS" {
-			LogInfo("build mobile app %v for PR %v in %v/%v succeeded!", build.Number, pr.Number, pr.RepoOwner, pr.RepoName)
+			mlog.Info(fmt.Sprintf("build mobile app %v for PR %v in %v/%v succeeded!", build.Number, pr.Number, pr.RepoOwner, pr.RepoName))
 			break
 		} else if build.Result == "FAILURE" {
-			LogError("build %v has status %v aborting.", build.Number, build.Result)
+			mlog.Error(fmt.Sprintf("build %v has status %v aborting.", build.Number, build.Result))
 			commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.BuildMobileAppFailedMessage)
 			return
 		} else {
-			LogInfo("build %v is running: %v", build.Number, build.Building)
+			mlog.Info(fmt.Sprintf("build %v is running: %v", build.Number, build.Building))
 		}
 		time.Sleep(60 * time.Second)
 	}
@@ -268,7 +269,7 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 func waitForBuild(client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRequest, bool) {
 	for {
 		if result := <-Srv.Store.PullRequest().Get(pr.RepoOwner, pr.RepoName, pr.Number); result.Err != nil {
-			LogError("Unable to get updated PR while waiting for spinmint: %v", result.Err.Error())
+			mlog.Error(fmt.Sprintf("Unable to get updated PR while waiting for spinmint: %v", result.Err.Error()))
 			return nil, false
 		} else {
 			// Update the PR in case the build link has changed because of a new commit
@@ -276,7 +277,7 @@ func waitForBuild(client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRe
 		}
 
 		if pr.BuildLink != "" {
-			LogInfo("BuildLink for %v in %v/%v is %v", pr.Number, pr.RepoOwner, pr.RepoName, pr.BuildLink)
+			mlog.Info(fmt.Sprintf("BuildLink for %v in %v/%v is %v", pr.Number, pr.RepoOwner, pr.RepoName, pr.BuildLink))
 			// Doing this because the lib we are using does not support folders :(
 			var jobNumber int64
 			var jobName string
@@ -289,27 +290,27 @@ func waitForBuild(client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRe
 				subJobName := parts[len(parts)-4] //PR-XXXX
 
 				jobName = "mp/job/" + jobName + "/job/" + subJobName
-				LogInfo("Job name for server: %v", jobName)
+				mlog.Info(fmt.Sprintf("Job name for server: %v", jobName))
 			} else if pr.RepoName == "mattermost-mobile" {
 				jobNumber, _ = strconv.ParseInt(parts[len(parts)-2], 10, 32)
 				jobName = parts[len(parts)-3] //mattermost-mobile
 				jobName = "mm/job/" + jobName
-				LogInfo("Job name for mobile: %v", jobName)
+				mlog.Info(fmt.Sprintf("Job name for mobile: %v", jobName))
 			} else if pr.RepoName == "mattermost-webapp" {
 				jobNumber, _ = strconv.ParseInt(parts[len(parts)-3], 10, 32)
 				jobName = parts[len(parts)-6]     //mattermost-webapp
 				subJobName := parts[len(parts)-4] //PR-XXXX
 
 				jobName = "mw/job/" + jobName + "/job/" + subJobName
-				LogInfo("Job name for webapp: %v", jobName)
+				mlog.Info(fmt.Sprintf("Job name for webapp: %v", jobName))
 			} else {
-				LogError("Did not know this repository: %v. Aborting.", pr.RepoName)
+				mlog.Error(fmt.Sprintf("Did not know this repository: %v. Aborting.", pr.RepoName))
 				return pr, false
 			}
 
 			job, err := client.GetJob(jobName)
 			if err != nil {
-				LogError("Failed to get Jenkins job %v: %v", jobName, err)
+				mlog.Error(fmt.Sprintf("Failed to get Jenkins job %v: %v", jobName, err))
 				return pr, false
 			}
 
@@ -324,19 +325,19 @@ func waitForBuild(client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRe
 			}
 
 			if !build.Building && build.Result == "SUCCESS" {
-				LogInfo("build %v for PR %v in %v/%v succeeded!", jobNumber, pr.Number, pr.RepoOwner, pr.RepoName)
+				mlog.Info(fmt.Sprintf("build %v for PR %v in %v/%v succeeded!", jobNumber, pr.Number, pr.RepoOwner, pr.RepoName))
 				return pr, true
 			} else if build.Result == "FAILURE" {
-				LogError("build %v has status %v aborting.", build.Number, build.Result)
+				mlog.Error(fmt.Sprintf("build %v has status %v aborting.", build.Number, build.Result))
 				return pr, false
 			} else {
-				LogInfo("build %v is running: %v", build.Number, build.Building)
+				mlog.Info(fmt.Sprintf("build %v is running: %v", build.Number, build.Building))
 			}
 		} else {
-			LogError("Unable to find build link for PR %v", pr.Number)
+			mlog.Error(fmt.Sprintf("Unable to find build link for PR %v", pr.Number))
 		}
 
-		LogInfo("Sleeping a bit....Will re-check the Jenkins Build...")
+		mlog.Info("Sleeping a bit....Will re-check the Jenkins Build...")
 		time.Sleep(30 * time.Second)
 	}
 	return pr, true
@@ -344,7 +345,7 @@ func waitForBuild(client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRe
 
 // Returns instance ID of instance created
 func setupSpinmint(prNumber int, prRef string, repo *Repository, upgrade bool) (*ec2.Instance, error) {
-	LogInfo("Setting up spinmint for PR: " + strconv.Itoa(prNumber))
+	mlog.Info("Setting up spinmint for PR: " + strconv.Itoa(prNumber))
 
 	svc := ec2.New(session.New(), Config.GetAwsConfig())
 
@@ -396,14 +397,14 @@ func setupSpinmint(prNumber int, prRef string, repo *Repository, upgrade bool) (
 		},
 	})
 	if errtag != nil {
-		LogError("Could not create tags for instance: " + *resp.Instances[0].InstanceId + " Error: " + errtag.Error())
+		mlog.Error(fmt.Sprintf("Could not create tags for instance: %v Error: %v", *resp.Instances[0].InstanceId, errtag.Error()))
 	}
 
 	return resp.Instances[0], nil
 }
 
 func destroySpinmint(pr *model.PullRequest, instanceId string) {
-	LogInfo("Destroying spinmint %v for PR %v in %v/%v", instanceId, pr.Number, pr.RepoOwner, pr.RepoName)
+	mlog.Info(fmt.Sprintf("Destroying spinmint %v for PR %v in %v/%v", instanceId, pr.Number, pr.RepoOwner, pr.RepoName))
 
 	svc := ec2.New(session.New(), Config.GetAwsConfig())
 
@@ -415,14 +416,14 @@ func destroySpinmint(pr *model.PullRequest, instanceId string) {
 
 	_, err := svc.TerminateInstances(params)
 	if err != nil {
-		LogError("Error terminating instances: " + err.Error())
+		mlog.Error(fmt.Sprintf("Error terminating instances: %v", err.Error()))
 		return
 	}
 
 	// Remove route53 entry
 	err = updateRoute53Subdomain(instanceId, "", "DELETE")
 	if err != nil {
-		LogError("Error removing the Route53 entry: " + err.Error())
+		mlog.Error(fmt.Sprintf("Error removing the Route53 entry: %v", err.Error()))
 		return
 	}
 
@@ -439,7 +440,7 @@ func getPublicDnsName(instance string) string {
 	}
 	resp, err := svc.DescribeInstances(params)
 	if err != nil {
-		LogError("Problem getting instance ip: " + err.Error())
+		mlog.Error(fmt.Sprintf("Problem getting instance ip: %v", err.Error()))
 		return ""
 	}
 
@@ -487,18 +488,18 @@ func updateRoute53Subdomain(name, target, action string) error {
 func checkSpinmintLifeTime() error {
 	spinmints := []*model.Spinmint{}
 	if result := <-Srv.Store.Spinmint().List(); result.Err != nil {
-		LogError("Unable to get updated PR while waiting for spinmint: %v", result.Err.Error())
+		mlog.Error(fmt.Sprintf("Unable to get updated PR while waiting for spinmint: %v", result.Err.Error()))
 		return result.Err
 	} else {
 		spinmints = result.Data.([]*model.Spinmint)
 	}
 
 	for _, spinmint := range spinmints {
-		LogInfo("Check if need destroy spinmint %v for PR %v in %v/%v", spinmint.InstanceId, spinmint.Number, spinmint.RepoOwner, spinmint.RepoName)
+		mlog.Info(fmt.Sprintf("Check if need destroy spinmint %v for PR %v in %v/%v", spinmint.InstanceId, spinmint.Number, spinmint.RepoOwner, spinmint.RepoName))
 		spinmintCreated := time.Unix(spinmint.CreatedAt, 0)
 		duration := time.Since(spinmintCreated)
 		if int(duration.Hours()) > Config.SpinmintExpirationHour {
-			LogInfo("Will destroy spinmint %v for PR %v in %v/%v", spinmint.InstanceId, spinmint.Number, spinmint.RepoOwner, spinmint.RepoName)
+			mlog.Info(fmt.Sprintf("Will destroy spinmint %v for PR %v in %v/%v", spinmint.InstanceId, spinmint.Number, spinmint.RepoOwner, spinmint.RepoName))
 			pr := &model.PullRequest{
 				RepoOwner: spinmint.RepoOwner,
 				RepoName:  spinmint.RepoName,
@@ -515,12 +516,12 @@ func checkSpinmintLifeTime() error {
 
 func storeSpinmintInfo(spinmint *model.Spinmint) {
 	if result := <-Srv.Store.Spinmint().Save(spinmint); result.Err != nil {
-		LogError(result.Err.Error())
+		mlog.Error(result.Err.Error())
 	}
 }
 
 func removeSpinmintInfo(instanceId string) {
 	if result := <-Srv.Store.Spinmint().Delete(instanceId); result.Err != nil {
-		LogError(result.Err.Error())
+		mlog.Error(result.Err.Error())
 	}
 }

--- a/server/spinmint.go
+++ b/server/spinmint.go
@@ -121,14 +121,14 @@ func waitForBuildAndSetupLoadtest(pr *model.PullRequest) {
 func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 	repo, ok := Config.GetRepository(pr.RepoOwner, pr.RepoName)
 	if !ok || repo.JenkinsServer == "" {
-		mlog.Error("Unable to set up spintmint for PR without Jenkins configured for server", mlog.Int("pr", pr.Number), mlog.String("repoowner", pr.RepoOwner), mlog.String("reponame", pr.RepoName))
+		mlog.Error("Unable to set up spintmint for PR without Jenkins configured for server", mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName))
 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.SetupSpinmintFailedMessage)
 		return
 	}
 
 	credentials, ok := Config.JenkinsCredentials[repo.JenkinsServer]
 	if !ok {
-		mlog.Error("No Jenkins credentials for server required for PR", mlog.String("jenkins", repo.JenkinsServer), mlog.Int("pr", pr.Number), mlog.String("repoowner", pr.RepoOwner), mlog.String("reponame", pr.RepoName))
+		mlog.Error("No Jenkins credentials for server required for PR", mlog.String("jenkins", repo.JenkinsServer), mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName))
 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.SetupSpinmintFailedMessage)
 		return
 	}
@@ -138,7 +138,7 @@ func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 		ApiToken: credentials.ApiToken,
 	}, credentials.URL)
 
-	mlog.Info("Waiting for Jenkins to build to set up spinmint for PR", mlog.Int("pr", pr.Number), mlog.String("repoowner", pr.RepoOwner), mlog.String("reponame", pr.RepoName))
+	mlog.Info("Waiting for Jenkins to build to set up spinmint for PR", mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName))
 
 	pr, errr := waitForBuild(client, pr)
 	if errr == false || pr == nil {
@@ -195,14 +195,14 @@ func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 func waitForMobileAppsBuild(pr *model.PullRequest) {
 	repo, ok := Config.GetRepository(pr.RepoOwner, pr.RepoName)
 	if !ok || repo.JenkinsServer == "" {
-		mlog.Error("Unable to build the mobile app for PR %v in %v/%v without Jenkins configured for server", mlog.Int("pr", pr.Number), mlog.String("repoowner", pr.RepoOwner), mlog.String("reponame", pr.RepoName))
+		mlog.Error("Unable to build the mobile app for PR %v in %v/%v without Jenkins configured for server", mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName))
 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.BuildMobileAppFailedMessage)
 		return
 	}
 
 	credentials, ok := Config.JenkinsCredentials[repo.JenkinsServer]
 	if !ok {
-		mlog.Error("No Jenkins credentials for server required for PR", mlog.String("jenkins", repo.JenkinsServer), mlog.Int("pr", pr.Number), mlog.String("repoowner", pr.RepoOwner), mlog.String("reponame", pr.RepoName))
+		mlog.Error("No Jenkins credentials for server required for PR", mlog.String("jenkins", repo.JenkinsServer), mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName))
 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.BuildMobileAppFailedMessage)
 		return
 	}
@@ -212,7 +212,7 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 		ApiToken: credentials.ApiToken,
 	}, credentials.URL)
 
-	mlog.Info("Waiting for Jenkins to build to start build the mobile app for PR", mlog.Int("pr", pr.Number), mlog.String("repoowner", pr.RepoOwner), mlog.String("reponame", pr.RepoName))
+	mlog.Info("Waiting for Jenkins to build to start build the mobile app for PR", mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName))
 
 	pr, errr := waitForBuild(client, pr)
 	if errr == false || pr == nil {
@@ -224,7 +224,7 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 	jobName := fmt.Sprintf("mm/job/%s", repo.JobName)
 	job, err := client.GetJob(jobName)
 	if err != nil {
-		mlog.Error("Failed to get Jenkins job", mlog.String("job", jobName), mlog.String("jenkinserror", err.Error()))
+		mlog.Error("Failed to get Jenkins job", mlog.String("job", jobName), mlog.String("jenkins_error", err.Error()))
 		return
 	}
 
@@ -233,7 +233,7 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 	parameters.Add("PR_NUMBER", strconv.Itoa(pr.Number))
 	err = client.Build(jobName, parameters)
 	if err != nil {
-		mlog.Error("Failed to build Jenkins job", mlog.String("job", jobName), mlog.String("jenkinserror", err.Error()))
+		mlog.Error("Failed to build Jenkins job", mlog.String("job", jobName), mlog.String("jenkins_error", err.Error()))
 		return
 	}
 
@@ -241,11 +241,11 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 	for {
 		build, err := client.GetLastBuild(job)
 		if err != nil {
-			mlog.Error("Failed to get the build Jenkins job", mlog.String("job", jobName), mlog.String("jenkinserror", err.Error()))
+			mlog.Error("Failed to get the build Jenkins job", mlog.String("job", jobName), mlog.String("jenkins_error", err.Error()))
 			return
 		}
 		if !build.Building && build.Result == "SUCCESS" {
-			mlog.Info("build mobile app for PR succeeded!", mlog.Int("build", build.Number), mlog.Int("pr", pr.Number), mlog.String("repoowner", pr.RepoOwner), mlog.String("reponame", pr.RepoName))
+			mlog.Info("build mobile app for PR succeeded!", mlog.Int("build", build.Number), mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName))
 			break
 		} else if build.Result == "FAILURE" {
 			mlog.Error("build has status FAILURE aborting.", mlog.Int("build", build.Number), mlog.String("result", build.Result))
@@ -269,7 +269,7 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 func waitForBuild(client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRequest, bool) {
 	for {
 		if result := <-Srv.Store.PullRequest().Get(pr.RepoOwner, pr.RepoName, pr.Number); result.Err != nil {
-			mlog.Error("Unable to get updated PR while waiting for spinmint", mlog.String("builderror", result.Err.Error()))
+			mlog.Error("Unable to get updated PR while waiting for spinmint", mlog.String("build_error", result.Err.Error()))
 			return nil, false
 		} else {
 			// Update the PR in case the build link has changed because of a new commit
@@ -277,7 +277,7 @@ func waitForBuild(client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRe
 		}
 
 		if pr.BuildLink != "" {
-			mlog.Info("BuildLink for PR", mlog.Int("pr", pr.Number), mlog.String("repoowner", pr.RepoOwner), mlog.String("reponame", pr.RepoName), mlog.String("buildlink", pr.BuildLink))
+			mlog.Info("BuildLink for PR", mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName), mlog.String("buildlink", pr.BuildLink))
 			// Doing this because the lib we are using does not support folders :(
 			var jobNumber int64
 			var jobName string
@@ -304,13 +304,13 @@ func waitForBuild(client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRe
 				jobName = "mw/job/" + jobName + "/job/" + subJobName
 				mlog.Info("Job name for webapp", mlog.String("job", jobName))
 			} else {
-				mlog.Error("Did not know this repository. Aborting.", mlog.String("reponame", pr.RepoName))
+				mlog.Error("Did not know this repository. Aborting.", mlog.String("repo_name", pr.RepoName))
 				return pr, false
 			}
 
 			job, err := client.GetJob(jobName)
 			if err != nil {
-				mlog.Error("Failed to get Jenkins job", mlog.String("job", jobName), mlog.String("jenkinserror", err.Error()))
+				mlog.Error("Failed to get Jenkins job", mlog.String("job", jobName), mlog.String("jenkins_error", err.Error()))
 				return pr, false
 			}
 
@@ -325,10 +325,10 @@ func waitForBuild(client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRe
 			}
 
 			if !build.Building && build.Result == "SUCCESS" {
-				mlog.Info("build for PR succeeded!", mlog.Int64("jobnumber", jobNumber), mlog.Int("pr", pr.Number), mlog.String("repoowner", pr.RepoOwner), mlog.String("reponame", pr.RepoName))
+				mlog.Info("build for PR succeeded!", mlog.Int64("jobnumber", jobNumber), mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName))
 				return pr, true
 			} else if build.Result == "FAILURE" {
-				mlog.Error("build has status FAILURE. Aborting.", mlog.Int("build", build.Number), mlog.String("builderror", build.Result))
+				mlog.Error("build has status FAILURE. Aborting.", mlog.Int("build", build.Number), mlog.String("build_error", build.Result))
 				return pr, false
 			} else {
 				mlog.Info("build is running", mlog.Int("build", build.Number), mlog.Bool("building", build.Building))
@@ -397,14 +397,14 @@ func setupSpinmint(prNumber int, prRef string, repo *Repository, upgrade bool) (
 		},
 	})
 	if errtag != nil {
-		mlog.Error("Could not create tags for instance", mlog.String("instance", *resp.Instances[0].InstanceId), mlog.String("tagerror", errtag.Error()))
+		mlog.Error("Could not create tags for instance", mlog.String("instance", *resp.Instances[0].InstanceId), mlog.String("tag_error", errtag.Error()))
 	}
 
 	return resp.Instances[0], nil
 }
 
 func destroySpinmint(pr *model.PullRequest, instanceId string) {
-	mlog.Info("Destroying spinmint for PR", mlog.String("instance", instanceId), mlog.Int("pr", pr.Number), mlog.String("repoowner", pr.RepoOwner), mlog.String("reponame", pr.RepoName))
+	mlog.Info("Destroying spinmint for PR", mlog.String("instance", instanceId), mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName))
 
 	svc := ec2.New(session.New(), Config.GetAwsConfig())
 
@@ -488,18 +488,18 @@ func updateRoute53Subdomain(name, target, action string) error {
 func checkSpinmintLifeTime() error {
 	spinmints := []*model.Spinmint{}
 	if result := <-Srv.Store.Spinmint().List(); result.Err != nil {
-		mlog.Error("Unable to get updated PR while waiting for spinmint", mlog.String("spinminterror", result.Err.Error()))
+		mlog.Error("Unable to get updated PR while waiting for spinmint", mlog.String("spinmint_error", result.Err.Error()))
 		return result.Err
 	} else {
 		spinmints = result.Data.([]*model.Spinmint)
 	}
 
 	for _, spinmint := range spinmints {
-		mlog.Info("Check if need destroy spinmint for PR", mlog.String("instance", spinmint.InstanceId), mlog.Int("spinmint", spinmint.Number), mlog.String("repoowner", spinmint.RepoOwner), mlog.String("reponame", spinmint.RepoName))
+		mlog.Info("Check if need destroy spinmint for PR", mlog.String("instance", spinmint.InstanceId), mlog.Int("spinmint", spinmint.Number), mlog.String("repo_owner", spinmint.RepoOwner), mlog.String("repo_name", spinmint.RepoName))
 		spinmintCreated := time.Unix(spinmint.CreatedAt, 0)
 		duration := time.Since(spinmintCreated)
 		if int(duration.Hours()) > Config.SpinmintExpirationHour {
-			mlog.Info("Will destroy spinmint for PR", mlog.String("instance", spinmint.InstanceId), mlog.Int("spinmint", spinmint.Number), mlog.String("repoowner", spinmint.RepoOwner), mlog.String("reponame", spinmint.RepoName))
+			mlog.Info("Will destroy spinmint for PR", mlog.String("instance", spinmint.InstanceId), mlog.Int("spinmint", spinmint.Number), mlog.String("repo_owner", spinmint.RepoOwner), mlog.String("repo_name", spinmint.RepoName))
 			pr := &model.PullRequest{
 				RepoOwner: spinmint.RepoOwner,
 				RepoName:  spinmint.RepoName,

--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	l4g "github.com/alecthomas/log4go"
 	"github.com/go-gorp/gorp"
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/mattermost/mattermost-server/mlog"
 )
 
 const (
@@ -63,15 +63,15 @@ func initConnection(driverName, dataSource string) *SqlStore {
 
 	db, err := dbsql.Open(driverName, dataSource)
 	if err != nil {
-		l4g.Critical("failed to open db connection", err)
+		mlog.Critical("failed to open db connection", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_DB_OPEN)
 	}
 
-	l4g.Info("pinging db")
+	mlog.Info("pinging db")
 	err = db.Ping()
 	if err != nil {
-		l4g.Critical("could not ping db: %v", err)
+		mlog.Critical("could not ping db: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_PING)
 	}
@@ -89,7 +89,7 @@ func NewSqlStore(driverName, dataSource string) Store {
 	sqlStore.spinmint = NewSqlSpinmintStore(sqlStore)
 
 	if err := sqlStore.master.CreateTablesIfNotExists(); err != nil {
-		l4g.Critical("error creating tables", err)
+		mlog.Critical("error creating tables", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_CREATE_TABLE)
 	}
@@ -117,7 +117,7 @@ func (ss *SqlStore) DoesTableExist(tableName string) bool {
 	)
 
 	if err != nil {
-		l4g.Critical("failed to check if table exists: %v", err)
+		mlog.Critical("failed to check if table exists: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_TABLE_EXISTS_MYSQL)
 	}
@@ -140,7 +140,7 @@ func (ss *SqlStore) DoesColumnExist(tableName string, columnName string) bool {
 	)
 
 	if err != nil {
-		l4g.Critical("failed to check if column exists: %v", err)
+		mlog.Critical("failed to check if column exists: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_DOES_COLUMN_EXISTS_MYSQL)
 	}
@@ -155,7 +155,7 @@ func (ss *SqlStore) CreateColumnIfNotExists(tableName string, columnName string,
 
 	_, err := ss.GetMaster().Exec("ALTER TABLE " + tableName + " ADD " + columnName + " " + mySqlColType + " DEFAULT '" + defaultValue + "'")
 	if err != nil {
-		l4g.Critical("failed to create column if not exists: %v", err)
+		mlog.Critical("failed to create column if not exists: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_CREATE_COLUMN_MYSQL)
 	}
@@ -171,7 +171,7 @@ func (ss *SqlStore) RemoveColumnIfExists(tableName string, columnName string) bo
 
 	_, err := ss.GetMaster().Exec("ALTER TABLE " + tableName + " DROP COLUMN " + columnName)
 	if err != nil {
-		l4g.Critical("failed to remove column if exists: %v", err)
+		mlog.Critical("failed to remove column if exists: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_REMOVE_COLUMN)
 	}
@@ -187,7 +187,7 @@ func (ss *SqlStore) RenameColumnIfExists(tableName string, oldColumnName string,
 	_, err := ss.GetMaster().Exec("ALTER TABLE " + tableName + " CHANGE " + oldColumnName + " " + newColumnName + " " + colType)
 
 	if err != nil {
-		l4g.Critical("failed to rename column if exists: %v", err)
+		mlog.Critical("failed to rename column if exists: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_RENAME_COLUMN)
 	}
@@ -203,7 +203,7 @@ func (ss *SqlStore) GetMaxLengthOfColumnIfExists(tableName string, columnName st
 	result, err := ss.GetMaster().SelectStr("SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_name = '" + tableName + "' AND COLUMN_NAME = '" + columnName + "'")
 
 	if err != nil {
-		l4g.Critical("failed to get max length of column if exists: %v", err)
+		mlog.Critical("failed to get max length of column if exists: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_MAX_COLUMN)
 	}
@@ -219,7 +219,7 @@ func (ss *SqlStore) AlterColumnTypeIfExists(tableName string, columnName string,
 	_, err := ss.GetMaster().Exec("ALTER TABLE " + tableName + " MODIFY " + columnName + " " + mySqlColType)
 
 	if err != nil {
-		l4g.Critical("failed to alter column type if exists: %v", err)
+		mlog.Critical("failed to alter column type if exists: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_ALTER_COLUMN)
 	}
@@ -248,7 +248,7 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 
 	count, err := ss.GetMaster().SelectInt("SELECT COUNT(0) AS index_exists FROM information_schema.statistics WHERE TABLE_SCHEMA = DATABASE() and table_name = ? AND index_name = ?", tableName, indexName)
 	if err != nil {
-		l4g.Critical("can't check for index: %v", err)
+		mlog.Critical("can't check for index: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_CREATE_INDEX_MYSQL)
 	}
@@ -264,7 +264,7 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 
 	_, err = ss.GetMaster().Exec("CREATE  " + uniqueStr + fullTextIndex + " INDEX " + indexName + " ON " + tableName + " (" + columnName + ")")
 	if err != nil {
-		l4g.Critical("failed to create index if not exists: %v", err)
+		mlog.Critical("failed to create index if not exists: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_CREATE_INDEX_FULL_MYSQL)
 	}
@@ -275,7 +275,7 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) bool {
 	count, err := ss.GetMaster().SelectInt("SELECT COUNT(0) AS index_exists FROM information_schema.statistics WHERE TABLE_SCHEMA = DATABASE() and table_name = ? AND index_name = ?", tableName, indexName)
 	if err != nil {
-		l4g.Critical("can't check index to remove: %v", err)
+		mlog.Critical("can't check index to remove: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_REMOVE_INDEX_MYSQL)
 	}
@@ -286,7 +286,7 @@ func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) bool
 
 	_, err = ss.GetMaster().Exec("DROP INDEX " + indexName + " ON " + tableName)
 	if err != nil {
-		l4g.Critical("failed to remove index if exists: %v", err)
+		mlog.Critical("failed to remove index if exists: %v", err)
 		time.Sleep(time.Second)
 		os.Exit(EXIT_REMOVE_INDEX_MYSQL)
 	}
@@ -322,7 +322,7 @@ func (ss *SqlStore) GetAllConns() []*gorp.DbMap {
 }
 
 func (ss *SqlStore) Close() {
-	l4g.Info("closing db")
+	mlog.Info("closing db")
 	ss.master.Db.Close()
 }
 

--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -7,7 +7,6 @@ import (
 	dbsql "database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -64,7 +63,7 @@ func initConnection(driverName, dataSource string) *SqlStore {
 
 	db, err := dbsql.Open(driverName, dataSource)
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("failed to open db connection %v", err))
+		mlog.Critical("failed to open db connection", mlog.String("dbconnection", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_DB_OPEN)
 	}
@@ -72,7 +71,7 @@ func initConnection(driverName, dataSource string) *SqlStore {
 	mlog.Info("pinging db")
 	err = db.Ping()
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("could not ping db: %v", err))
+		mlog.Critical("could not ping db", mlog.String("dbping", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_PING)
 	}
@@ -90,7 +89,7 @@ func NewSqlStore(driverName, dataSource string) Store {
 	sqlStore.spinmint = NewSqlSpinmintStore(sqlStore)
 
 	if err := sqlStore.master.CreateTablesIfNotExists(); err != nil {
-		mlog.Critical(fmt.Sprintf("error creating tables %v", err))
+		mlog.Critical("error creating tables", mlog.String("dbtables", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_CREATE_TABLE)
 	}
@@ -118,7 +117,7 @@ func (ss *SqlStore) DoesTableExist(tableName string) bool {
 	)
 
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("failed to check if table exists: %v", err))
+		mlog.Critical("failed to check if table exists", mlog.String("dbtable", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_TABLE_EXISTS_MYSQL)
 	}
@@ -141,7 +140,7 @@ func (ss *SqlStore) DoesColumnExist(tableName string, columnName string) bool {
 	)
 
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("failed to check if column exists: %v", err))
+		mlog.Critical("failed to check if column exists", mlog.String("dbcolumn", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_DOES_COLUMN_EXISTS_MYSQL)
 	}
@@ -156,7 +155,7 @@ func (ss *SqlStore) CreateColumnIfNotExists(tableName string, columnName string,
 
 	_, err := ss.GetMaster().Exec("ALTER TABLE " + tableName + " ADD " + columnName + " " + mySqlColType + " DEFAULT '" + defaultValue + "'")
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("failed to create column if not exists: %v", err))
+		mlog.Critical("failed to create column if not exists: %v", mlog.String("dbcolumn", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_CREATE_COLUMN_MYSQL)
 	}
@@ -172,7 +171,7 @@ func (ss *SqlStore) RemoveColumnIfExists(tableName string, columnName string) bo
 
 	_, err := ss.GetMaster().Exec("ALTER TABLE " + tableName + " DROP COLUMN " + columnName)
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("failed to remove column if exists: %v", err))
+		mlog.Critical("failed to remove column if exists", mlog.String("dbcolumn", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_REMOVE_COLUMN)
 	}
@@ -188,7 +187,7 @@ func (ss *SqlStore) RenameColumnIfExists(tableName string, oldColumnName string,
 	_, err := ss.GetMaster().Exec("ALTER TABLE " + tableName + " CHANGE " + oldColumnName + " " + newColumnName + " " + colType)
 
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("failed to rename column if exists: %v", err))
+		mlog.Critical("failed to rename column if exists", mlog.String("dbcolumn", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_RENAME_COLUMN)
 	}
@@ -204,7 +203,7 @@ func (ss *SqlStore) GetMaxLengthOfColumnIfExists(tableName string, columnName st
 	result, err := ss.GetMaster().SelectStr("SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_name = '" + tableName + "' AND COLUMN_NAME = '" + columnName + "'")
 
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("failed to get max length of column if exists: %v", err))
+		mlog.Critical("failed to get max length of column if exists", mlog.String("dbcolumn", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_MAX_COLUMN)
 	}
@@ -220,7 +219,7 @@ func (ss *SqlStore) AlterColumnTypeIfExists(tableName string, columnName string,
 	_, err := ss.GetMaster().Exec("ALTER TABLE " + tableName + " MODIFY " + columnName + " " + mySqlColType)
 
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("failed to alter column type if exists: %v", err))
+		mlog.Critical("failed to alter column type if exists", mlog.String("dbcolumn", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_ALTER_COLUMN)
 	}
@@ -249,7 +248,7 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 
 	count, err := ss.GetMaster().SelectInt("SELECT COUNT(0) AS index_exists FROM information_schema.statistics WHERE TABLE_SCHEMA = DATABASE() and table_name = ? AND index_name = ?", tableName, indexName)
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("can't check for index: %v", err))
+		mlog.Critical("can't check for index", mlog.String("dbindex", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_CREATE_INDEX_MYSQL)
 	}
@@ -265,7 +264,7 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 
 	_, err = ss.GetMaster().Exec("CREATE  " + uniqueStr + fullTextIndex + " INDEX " + indexName + " ON " + tableName + " (" + columnName + ")")
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("failed to create index if not exists: %v", err))
+		mlog.Critical("failed to create index if not exists", mlog.String("dbindex", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_CREATE_INDEX_FULL_MYSQL)
 	}
@@ -276,7 +275,7 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) bool {
 	count, err := ss.GetMaster().SelectInt("SELECT COUNT(0) AS index_exists FROM information_schema.statistics WHERE TABLE_SCHEMA = DATABASE() and table_name = ? AND index_name = ?", tableName, indexName)
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("can't check index to remove: %v", err))
+		mlog.Critical("can't check index to remove", mlog.String("dbindex", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_REMOVE_INDEX_MYSQL)
 	}
@@ -287,7 +286,7 @@ func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) bool
 
 	_, err = ss.GetMaster().Exec("DROP INDEX " + indexName + " ON " + tableName)
 	if err != nil {
-		mlog.Critical(fmt.Sprintf("failed to remove index if exists: %v", err))
+		mlog.Critical("failed to remove index if exists", mlog.String("dbindex", err.Error()))
 		time.Sleep(time.Second)
 		os.Exit(EXIT_REMOVE_INDEX_MYSQL)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -6,7 +6,6 @@ package store
 import (
 	"time"
 
-	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/mattermost-mattermod/model"
 )
 
@@ -20,7 +19,6 @@ type StoreChannel chan StoreResult
 func Must(sc StoreChannel) interface{} {
 	r := <-sc
 	if r.Err != nil {
-		l4g.Close()
 		time.Sleep(time.Second)
 		panic(r.Err)
 	}


### PR DESCRIPTION
#### Summary
This PR drops the use of l4g (unmaintained) and replace it by mlog, which is Mattermost wrapper around Uber's zap logging lib.

The original ticket suggested to include a CLI to pull or monitor logs or factor out mlog out of Mattermost code base.
I'm more inclined for factoring out mlog and could even lead the effort if necessary. IMO having a few CLI for mlog would be best.

#### Ticket Link
[MM-11148](https://mattermost.atlassian.net/browse/MM-11148)