### PR TITLE
[MM-17073] Mattermod Refactor #2

### DIFF
--- a/cloud/installation.go
+++ b/cloud/installation.go
@@ -1,0 +1,90 @@
+package cloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// GetInstallation returns an installation for a given ID.
+func GetInstallation(serverURL, installationID string) (Installation, error) {
+	var installation Installation
+	url := fmt.Sprintf("%s/api/installation/%s", serverURL, installationID)
+	resp, err := makeRequest("GET", url, nil)
+	if err != nil {
+		return installation, errors.Wrap(err, "unable to get installation")
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&installation)
+	if err != nil && err != io.EOF {
+		return installation, errors.Wrap(err, "Error decoding installation")
+	}
+
+	return installation, nil
+}
+
+// GetInstallationList returns a list on non-deleted installations from the
+// provisioning server.
+func GetInstallationList(serverURL string) ([]Installation, error) {
+	var installations []Installation
+
+	url := fmt.Sprintf("%s/api/installations", serverURL)
+	resp, err := makeRequest("GET", url, nil)
+	if err != nil {
+		return installations, errors.Wrap(err, "error gettings installations")
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&installations)
+	if err != nil && err != io.EOF {
+		return installations, errors.Wrap(err, "error decoding installations")
+	}
+
+	return installations, nil
+}
+
+// GetInstallationIDFromOwnerID returns the ID of an installtion that matches
+// a given OwnerID. Multiple matches will return an error. No match will return
+// an empty ID and no error.
+func GetInstallationIDFromOwnerID(serverURL, ownerID string) (string, error) {
+	installations, err := GetInstallationList(serverURL)
+	if err != nil {
+		return "", err
+	}
+
+	var matchingInstallations []Installation
+	for _, installation := range installations {
+		if installation.OwnerID == ownerID {
+			matchingInstallations = append(matchingInstallations, installation)
+		}
+	}
+
+	if len(matchingInstallations) == 0 {
+		return "", nil
+	}
+	if len(matchingInstallations) == 1 {
+		return matchingInstallations[0].ID, nil
+	}
+
+	return "", fmt.Errorf("found %d installations with ownerID %s", len(matchingInstallations), ownerID)
+}
+
+func makeRequest(method, url string, payload io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, payload)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/cloud/installation.go
+++ b/cloud/installation.go
@@ -47,7 +47,7 @@ func GetInstallationList(serverURL string) ([]Installation, error) {
 	return installations, nil
 }
 
-// GetInstallationIDFromOwnerID returns the ID of an installtion that matches
+// GetInstallationIDFromOwnerID returns the ID of an installation that matches
 // a given OwnerID. Multiple matches will return an error. No match will return
 // an empty ID and no error.
 func GetInstallationIDFromOwnerID(serverURL, ownerID string) (string, error) {

--- a/cloud/models.go
+++ b/cloud/models.go
@@ -1,0 +1,56 @@
+package cloud
+
+// The following structs are copied from the mattermost-cloud repo to allow
+// mattermod to interact with provisioning servers.
+//
+// TODO: consider moving the structs in mattermost-cloud for these models out
+// of the /internal directory so that they can be vendored and imported here.
+// When doing this, we should start using semver in the mattermost-cloud repo.
+
+// CreateClusterRequest specifies the parameters for a new cluster.
+type CreateClusterRequest struct {
+	Provider string
+	Size     string
+	Zones    []string
+}
+
+// Cluster represents a Kubernetes cluster.
+type Cluster struct {
+	ID                  string
+	Provider            string
+	Provisioner         string
+	ProviderMetadata    []byte `json:",omitempty"`
+	ProvisionerMetadata []byte `json:",omitempty"`
+	AllowInstallations  bool
+	Size                string
+	State               string
+	CreateAt            int64
+	DeleteAt            int64
+	LockAcquiredBy      *string
+	LockAcquiredAt      int64
+}
+
+// CreateInstallationRequest specifies the parameters for a new installation.
+type CreateInstallationRequest struct {
+	OwnerID  string
+	Version  string
+	DNS      string
+	Size     string
+	Affinity string
+}
+
+// Installation represents a Mattermost installation.
+type Installation struct {
+	ID             string
+	OwnerID        string
+	Version        string
+	DNS            string
+	Size           string
+	Affinity       string
+	GroupID        *string
+	State          string
+	CreateAt       int64
+	DeleteAt       int64
+	LockAcquiredBy *string
+	LockAcquiredAt int64
+}

--- a/model/pull_request.go
+++ b/model/pull_request.go
@@ -25,6 +25,7 @@ type PullRequest struct {
 	BuildStatus     string
 	BuildConclusion string
 	BuildLink       string
+	URL             string
 }
 
 func (o *PullRequest) ToJson() (string, error) {

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -79,7 +79,7 @@ func (s *Server) checkIfNeedCherryPick(pr *model.PullRequest) {
 		mlog.Error("Error listing the labels for PR", mlog.Err(err))
 		return
 	}
-	prLabels := LabelsToStringArray(labels)
+	prLabels := labelsToStringArray(labels)
 	for _, prLabel := range prLabels {
 		if prLabel == "CherryPick/Approved" {
 			cmdOut, err := s.doCherryPick(milestone, pr)

--- a/server/github.go
+++ b/server/github.go
@@ -12,14 +12,14 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func NewGithubClient() *github.Client {
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: Config.GithubAccessToken})
+func NewGithubClient(token string) *github.Client {
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(oauth2.NoContext, ts)
 
 	return github.NewClient(tc)
 }
 
-func GetPullRequestFromGithub(pullRequest *github.PullRequest) (*model.PullRequest, error) {
+func (s *Server) GetPullRequestFromGithub(pullRequest *github.PullRequest) (*model.PullRequest, error) {
 	pr := &model.PullRequest{
 		RepoOwner: *pullRequest.Base.Repo.Owner.Login,
 		RepoName:  *pullRequest.Base.Repo.Name,
@@ -30,9 +30,9 @@ func GetPullRequestFromGithub(pullRequest *github.PullRequest) (*model.PullReque
 		State:     *pullRequest.State,
 	}
 
-	client := NewGithubClient()
+	client := NewGithubClient(s.Config.GithubAccessToken)
 
-	repo, ok := Config.GetRepository(pr.RepoOwner, pr.RepoName)
+	repo, ok := s.GetRepository(pr.RepoOwner, pr.RepoName)
 	if ok && repo.BuildStatusContext != "" {
 		if combined, _, err := client.Repositories.GetCombinedStatus(context.Background(), pr.RepoOwner, pr.RepoName, pr.Sha, nil); err != nil {
 			return nil, err
@@ -70,7 +70,7 @@ func GetPullRequestFromGithub(pullRequest *github.PullRequest) (*model.PullReque
 	return pr, nil
 }
 
-func GetIssueFromGithub(repoOwner, repoName string, ghIssue *github.Issue) (*model.Issue, error) {
+func (s *Server) GetIssueFromGithub(repoOwner, repoName string, ghIssue *github.Issue) (*model.Issue, error) {
 	issue := &model.Issue{
 		RepoOwner: repoOwner,
 		RepoName:  repoName,
@@ -79,7 +79,7 @@ func GetIssueFromGithub(repoOwner, repoName string, ghIssue *github.Issue) (*mod
 		State:     *ghIssue.State,
 	}
 
-	if labels, _, err := NewGithubClient().Issues.ListLabelsByIssue(context.Background(), issue.RepoOwner, issue.RepoName, issue.Number, nil); err != nil {
+	if labels, _, err := NewGithubClient(s.Config.GithubAccessToken).Issues.ListLabelsByIssue(context.Background(), issue.RepoOwner, issue.RepoName, issue.Number, nil); err != nil {
 		return nil, err
 	} else {
 		issue.Labels = LabelsToStringArray(labels)
@@ -98,9 +98,9 @@ func LabelsToStringArray(labels []*github.Label) []string {
 	return out
 }
 
-func commentOnIssue(repoOwner, repoName string, number int, comment string) {
+func (s *Server) commentOnIssue(repoOwner, repoName string, number int, comment string) {
 	mlog.Info("Commenting on issue", mlog.Int("issue", number), mlog.String("comment", comment))
-	client := NewGithubClient()
+	client := NewGithubClient(s.Config.GithubAccessToken)
 	_, _, err := client.Issues.CreateComment(context.Background(), repoOwner, repoName, number, &github.IssueComment{Body: &comment})
 	if err != nil {
 		mlog.Error("Error", mlog.Err(err))
@@ -108,24 +108,24 @@ func commentOnIssue(repoOwner, repoName string, number int, comment string) {
 	mlog.Info("Finished commenting")
 }
 
-func GetUpdateChecks(owner, repoName string, prNumber int) (*model.PullRequest, error) {
-	client := NewGithubClient()
+func (s *Server) GetUpdateChecks(owner, repoName string, prNumber int) (*model.PullRequest, error) {
+	client := NewGithubClient(s.Config.GithubAccessToken)
 	prGitHub, _, err := client.PullRequests.Get(context.Background(), owner, repoName, prNumber)
-	pr, err := GetPullRequestFromGithub(prGitHub)
+	pr, err := s.GetPullRequestFromGithub(prGitHub)
 	if err != nil {
 		mlog.Error("pr_error", mlog.Err(err))
 		return nil, err
 	}
 
-	if result := <-Srv.Store.PullRequest().Save(pr); result.Err != nil {
+	if result := <-s.Store.PullRequest().Save(pr); result.Err != nil {
 		mlog.Error(result.Err.Error())
 	}
 
 	return pr, nil
 }
 
-func checkUserPermission(user, repoOwner string) bool {
-	client := NewGithubClient()
+func (s *Server) checkUserPermission(user, repoOwner string) bool {
+	client := NewGithubClient(s.Config.GithubAccessToken)
 
 	_, resp, err := client.Organizations.GetOrgMembership(context.Background(), user, repoOwner)
 	if resp.StatusCode == 404 {

--- a/server/github.go
+++ b/server/github.go
@@ -28,6 +28,7 @@ func (s *Server) GetPullRequestFromGithub(pullRequest *github.PullRequest) (*mod
 		Ref:       *pullRequest.Head.Ref,
 		Sha:       *pullRequest.Head.SHA,
 		State:     *pullRequest.State,
+		URL:       *pullRequest.URL,
 	}
 
 	client := NewGithubClient(s.Config.GithubAccessToken)
@@ -64,7 +65,7 @@ func (s *Server) GetPullRequestFromGithub(pullRequest *github.PullRequest) (*mod
 	if labels, _, err := client.Issues.ListLabelsByIssue(context.Background(), pr.RepoOwner, pr.RepoName, pr.Number, nil); err != nil {
 		return nil, err
 	} else {
-		pr.Labels = LabelsToStringArray(labels)
+		pr.Labels = labelsToStringArray(labels)
 	}
 
 	return pr, nil
@@ -82,13 +83,13 @@ func (s *Server) GetIssueFromGithub(repoOwner, repoName string, ghIssue *github.
 	if labels, _, err := NewGithubClient(s.Config.GithubAccessToken).Issues.ListLabelsByIssue(context.Background(), issue.RepoOwner, issue.RepoName, issue.Number, nil); err != nil {
 		return nil, err
 	} else {
-		issue.Labels = LabelsToStringArray(labels)
+		issue.Labels = labelsToStringArray(labels)
 	}
 
 	return issue, nil
 }
 
-func LabelsToStringArray(labels []*github.Label) []string {
+func labelsToStringArray(labels []*github.Label) []string {
 	out := make([]string, len(labels))
 
 	for i, label := range labels {

--- a/server/github_pr.go
+++ b/server/github_pr.go
@@ -15,6 +15,8 @@ type PullRequestEvent struct {
 	PRNumber      int                 `json:"number"`
 	PullRequest   *github.PullRequest `json:"pull_request"`
 	Issue         *github.Issue       `json:"issue"`
+	Label         *github.Label       `json:"label"`
+	Repo          *github.Repository  `json:"repository"`
 	RepositoryUrl string              `json:"repository_url"`
 }
 
@@ -31,6 +33,7 @@ func PullRequestEventFromJson(data io.Reader) *PullRequestEvent {
 	if err := decoder.Decode(&event); err != nil {
 		return nil
 	}
+
 	return &event
 }
 
@@ -40,5 +43,6 @@ func IssueCommentFromJson(data io.Reader) *IssueComment {
 	if err := decoder.Decode(&event); err != nil {
 		return nil
 	}
+
 	return &event
 }

--- a/server/issue.go
+++ b/server/issue.go
@@ -13,27 +13,27 @@ import (
 	"github.com/mattermost/mattermost-server/mlog"
 )
 
-func handleIssueEvent(event *PullRequestEvent) {
+func (s *Server) handleIssueEvent(event *PullRequestEvent) {
 	mlog.Info("Handle Issue event", mlog.Any("Issue HTMLURL", *event.Issue))
 	parts := strings.Split(*event.Issue.HTMLURL, "/")
 
 	mlog.Info("handle issue event", mlog.String("repoUrl", *event.Issue.HTMLURL), mlog.String("Action", event.Action), mlog.Int("PRNumber", event.PRNumber))
-	issue, err := GetIssueFromGithub(parts[len(parts)-4], parts[len(parts)-3], event.Issue)
+	issue, err := s.GetIssueFromGithub(parts[len(parts)-4], parts[len(parts)-3], event.Issue)
 	if err != nil {
 		mlog.Error("Error getting the issue from Github", mlog.Err(err))
 		return
 	}
 
-	checkIssueForChanges(issue)
+	s.checkIssueForChanges(issue)
 }
 
-func checkIssueForChanges(issue *model.Issue) {
+func (s *Server) checkIssueForChanges(issue *model.Issue) {
 	var oldIssue *model.Issue
-	if result := <-Srv.Store.Issue().Get(issue.RepoOwner, issue.RepoName, issue.Number); result.Err != nil {
+	if result := <-s.Store.Issue().Get(issue.RepoOwner, issue.RepoName, issue.Number); result.Err != nil {
 		mlog.Error(result.Err.Error())
 		return
 	} else if result.Data == nil {
-		if resultSave := <-Srv.Store.Issue().Save(issue); resultSave.Err != nil {
+		if resultSave := <-s.Store.Issue().Save(issue); resultSave.Err != nil {
 			mlog.Error(resultSave.Err.Error())
 		}
 		return
@@ -59,7 +59,7 @@ func checkIssueForChanges(issue *model.Issue) {
 
 		if !hadLabel {
 			mlog.Info("issue added label", mlog.Int("issue", issue.Number), mlog.String("label", label))
-			handleIssueLabeled(issue, label)
+			s.handleIssueLabeled(issue, label)
 			hasChanges = true
 		}
 	}
@@ -67,19 +67,19 @@ func checkIssueForChanges(issue *model.Issue) {
 	if hasChanges {
 		mlog.Info("issue has changes", mlog.Int("issue", issue.Number))
 
-		if result := <-Srv.Store.Issue().Save(issue); result.Err != nil {
+		if result := <-s.Store.Issue().Save(issue); result.Err != nil {
 			mlog.Error(result.Err.Error())
 			return
 		}
 	}
 }
 
-func handleIssueLabeled(issue *model.Issue, addedLabel string) {
-	client := NewGithubClient()
+func (s *Server) handleIssueLabeled(issue *model.Issue, addedLabel string) {
+	client := NewGithubClient(s.Config.GithubAccessToken)
 
 	// Must be sure the comment is created before we let anouther request test
-	commentLock.Lock()
-	defer commentLock.Unlock()
+	s.commentLock.Lock()
+	defer s.commentLock.Unlock()
 
 	comments, _, err := client.Issues.ListComments(context.Background(), issue.RepoOwner, issue.RepoName, issue.Number, nil)
 	if err != nil {
@@ -87,20 +87,20 @@ func handleIssueLabeled(issue *model.Issue, addedLabel string) {
 		return
 	}
 
-	for _, label := range Config.IssueLabels {
+	for _, label := range s.Config.IssueLabels {
 		finalMessage := strings.Replace(label.Message, "USERNAME", issue.Username, -1)
-		if label.Label == addedLabel && !messageByUserContains(comments, Config.Username, finalMessage) {
+		if label.Label == addedLabel && !messageByUserContains(comments, s.Config.Username, finalMessage) {
 			mlog.Info("Posted message for label on PR", mlog.String("label", label.Label), mlog.Int("issue", issue.Number))
-			commentOnIssue(issue.RepoOwner, issue.RepoName, issue.Number, finalMessage)
+			s.commentOnIssue(issue.RepoOwner, issue.RepoName, issue.Number, finalMessage)
 		}
 	}
 }
 
-func CleanOutdatedIssues() {
+func (s *Server) CleanOutdatedIssues() {
 	mlog.Info("Cleaning outdated issues in the mattermod database....")
 
 	var issues []*model.Issue
-	if result := <-Srv.Store.Issue().ListOpen(); result.Err != nil {
+	if result := <-s.Store.Issue().ListOpen(); result.Err != nil {
 		mlog.Error(result.Err.Error())
 		return
 	} else {
@@ -109,21 +109,21 @@ func CleanOutdatedIssues() {
 
 	mlog.Info("Will process the Issues", mlog.Int("Issues Count", len(issues)))
 
-	client := NewGithubClient()
+	client := NewGithubClient(s.Config.GithubAccessToken)
 	for _, issue := range issues {
 		ghIssue, _, errIssue := client.Issues.Get(context.Background(), issue.RepoOwner, issue.RepoName, issue.Number)
 		if errIssue != nil {
 			mlog.Error("Error getting Pull Request", mlog.String("RepoOwner", issue.RepoOwner), mlog.String("RepoName", issue.RepoName), mlog.Int("PRNumber", issue.Number), mlog.Err(errIssue))
 			if _, ok := errIssue.(*github.RateLimitError); ok {
 				mlog.Error("GitHub rate limit reached")
-				CheckLimitRateAndSleep()
+				s.CheckLimitRateAndSleep()
 			}
 		}
 
 		if *ghIssue.State == "closed" {
 			mlog.Info("Issue is closed, updating the status in the database", mlog.String("RepoOwner", issue.RepoOwner), mlog.String("RepoName", issue.RepoName), mlog.Int("IssueNumber", issue.Number))
 			issue.State = *ghIssue.State
-			if result := <-Srv.Store.Issue().Save(issue); result.Err != nil {
+			if result := <-s.Store.Issue().Save(issue); result.Err != nil {
 				mlog.Error(result.Err.Error())
 			}
 		} else {

--- a/server/limit_rate_gh.go
+++ b/server/limit_rate_gh.go
@@ -10,10 +10,10 @@ import (
 	"github.com/mattermost/mattermost-server/mlog"
 )
 
-func CheckLimitRateAndSleep() {
+func (s *Server) CheckLimitRateAndSleep() {
 	mlog.Info("Checking the rate limit on Github and will sleep if need...")
 
-	client := NewGithubClient()
+	client := NewGithubClient(s.Config.GithubAccessToken)
 	rate, _, err := client.RateLimits(context.Background())
 	if err != nil {
 		mlog.Error("Error getting the rate limit", mlog.Err(err))
@@ -21,19 +21,19 @@ func CheckLimitRateAndSleep() {
 		return
 	}
 	mlog.Info("Current rate limit", mlog.Int("Remaining Rate", rate.Core.Remaining), mlog.Int("Limit Rate", rate.Core.Limit))
-	if rate.Core.Remaining <= Config.GitHubTokenReserve {
+	if rate.Core.Remaining <= s.Config.GitHubTokenReserve {
 		sleepDuration := time.Until(rate.Core.Reset.Time) + (time.Second * 10)
 		if sleepDuration > 0 {
-			mlog.Error("--Rate Limiting-- Tokens reached minimum reserve. Sleeping until reset in", mlog.Int("Minimun", Config.GitHubTokenReserve), mlog.Any("Sleep time", sleepDuration))
+			mlog.Error("--Rate Limiting-- Tokens reached minimum reserve. Sleeping until reset in", mlog.Int("Minimun", s.Config.GitHubTokenReserve), mlog.Any("Sleep time", sleepDuration))
 			time.Sleep(sleepDuration)
 		}
 	}
 }
 
-func CheckLimitRateAndAbortRequest() bool {
+func (s *Server) CheckLimitRateAndAbortRequest() bool {
 	mlog.Info("Checking the rate limit on Github and will abort request if need...")
 
-	client := NewGithubClient()
+	client := NewGithubClient(s.Config.GithubAccessToken)
 	rate, _, err := client.RateLimits(context.Background())
 	if err != nil {
 		mlog.Error("Error getting the rate limit", mlog.Err(err))
@@ -41,7 +41,7 @@ func CheckLimitRateAndAbortRequest() bool {
 		return false
 	}
 	mlog.Info("Current rate limit", mlog.Int("Remaining Rate", rate.Core.Remaining), mlog.Int("Limit Rate", rate.Core.Limit))
-	if rate.Core.Remaining <= Config.GitHubTokenReserve {
+	if rate.Core.Remaining <= s.Config.GitHubTokenReserve {
 		mlog.Info("Request will be aborted...")
 		return true
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -278,9 +278,9 @@ func (s *Server) deleteTestServer(w http.ResponseWriter, r *http.Request) {
 
 	if strings.Contains(testServer.InstanceId, "i-") {
 		s.destroySpinmint(pr, testServer.InstanceId)
-	} else {
-		s.handleDestroySpinWick(pr, testServer.InstanceId)
 	}
+
+	s.handleDestroySpinWick(pr)
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/server/spinmint.go
+++ b/server/spinmint.go
@@ -427,7 +427,7 @@ func (s *Server) CheckTestServerLifeTime() {
 		mlog.Info("Check if need destroy Test Server for PR", mlog.String("instance", testServer.InstanceId), mlog.Int("TestServer", testServer.Number), mlog.String("repo_owner", testServer.RepoOwner), mlog.String("repo_name", testServer.RepoName))
 		testServerCreated := time.Unix(testServer.CreatedAt, 0)
 		duration := time.Since(testServerCreated)
-		if int(duration.Hours()) > Config.SpinmintExpirationHour {
+		if int(duration.Hours()) > s.Config.SpinmintExpirationHour {
 			mlog.Info("Will destroy spinmint for PR", mlog.String("instance", testServer.InstanceId), mlog.Int("TestServer", testServer.Number), mlog.String("repo_owner", testServer.RepoOwner), mlog.String("repo_name", testServer.RepoName))
 			pr := &model.PullRequest{
 				RepoOwner: testServer.RepoOwner,
@@ -436,7 +436,7 @@ func (s *Server) CheckTestServerLifeTime() {
 			}
 			go s.destroySpinmint(pr, testServer.InstanceId)
 			s.removeTestServerFromDB(testServer.InstanceId)
-			commentOnIssue(testServer.RepoOwner, testServer.RepoName, testServer.Number, Config.DestroyedExpirationSpinmintMessage)
+			s.commentOnIssue(testServer.RepoOwner, testServer.RepoName, testServer.Number, s.Config.DestroyedExpirationSpinmintMessage)
 		}
 	}
 

--- a/server/spinmint.go
+++ b/server/spinmint.go
@@ -27,17 +27,17 @@ import (
 
 // TODO FIXME
 // func waitForBuildAndSetupLoadtest(pr *model.PullRequest) {
-// 	repo, ok := Config.GetRepository(pr.RepoOwner, pr.RepoName)
+// 	repo, ok := s.Config.GetRepository(pr.RepoOwner, pr.RepoName)
 // 	if !ok || repo.JenkinsServer == "" {
 // 		LogError("Unable to set up loadtest for PR %v in %v/%v without Jenkins configured for server", pr.Number, pr.RepoOwner, pr.RepoName)
-// 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
+// 		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
 // 		return
 // 	}
 
-// 	credentials, ok := Config.JenkinsCredentials[repo.JenkinsServer]
+// 	credentials, ok := s.Config.JenkinsCredentials[repo.JenkinsServer]
 // 	if !ok {
 // 		LogError("No Jenkins credentials for server %v required for PR %v in %v/%v", repo.JenkinsServer, pr.Number, pr.RepoOwner, pr.RepoName)
-// 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
+// 		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
 // 		return
 // 	}
 
@@ -58,13 +58,13 @@ import (
 // 		DBInstanceCount:       4,
 // 		LoadtestInstanceCount: 1,
 // 	}
-// 	config.WorkingDirectory = filepath.Join("./clusters/", config.Name)
+// 	s.Config.WorkingDirectory = filepath.Join("./clusters/", s.Config.Name)
 
 // 	LogInfo("Creating terraform cluster for loadtest for PR %v in %v/%v", pr.Number, pr.RepoOwner, pr.RepoName)
 // 	cluster, err := terraform.CreateCluster(config)
 // 	if err != nil {
 // 		LogError("Unable to setup cluster: " + err.Error())
-// 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
+// 		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
 // 	}
 // 	// Wait for the cluster to init
 // 	time.Sleep(time.Minute)
@@ -74,12 +74,12 @@ import (
 // 	LogInfo("Deploying to cluster for loadtest for PR %v in %v/%v", pr.Number, pr.RepoOwner, pr.RepoName)
 // 	if err := cluster.Deploy("https://releases.mattermost.com/mattermost-platform-pr/"+strconv.Itoa(pr.Number)+"/mattermost-enterprise-linux-amd64.tar.gz", "mattermod.mattermost-license"); err != nil {
 // 		LogError("Unable to deploy cluster: " + err.Error())
-// 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
+// 		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
 // 		return
 // 	}
 // 	if err := cluster.Loadtest("https://releases.mattermost.com/mattermost-load-test/mattermost-load-test.tar.gz"); err != nil {
 // 		LogError("Unable to deploy loadtests to cluster: " + err.Error())
-// 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
+// 		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
 // 		return
 // 	}
 
@@ -89,13 +89,13 @@ import (
 // 	LogInfo("Runing loadtest for PR %v in %v/%v", pr.Number, pr.RepoOwner, pr.RepoName)
 // 	if err := cluster.Loadtest(results); err != nil {
 // 		LogError("Unable to loadtest cluster: " + err.Error())
-// 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
+// 		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
 // 		return
 // 	}
 // 	LogInfo("Destroying cluster for PR %v in %v/%v", pr.Number, pr.RepoOwner, pr.RepoName)
 // 	if err := cluster.Destroy(); err != nil {
 // 		LogError("Unable to destroy cluster: " + err.Error())
-// 		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
+// 		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")
 // 		return
 // 	}
 
@@ -109,17 +109,17 @@ import (
 
 // 	ltparse.ParseResults(&cfg)
 // 	LogInfo("Loadtest results for PR %v in %v/%v\n%v", pr.Number, pr.RepoOwner, pr.RepoName, githubOutput.String())
-// 	commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, githubOutput.String())
+// 	s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, githubOutput.String())
 // }
 func waitForBuildAndSetupLoadtest(pr *model.PullRequest) {
 	return
 }
 
-func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
-	repo, client, err := buildJenkinsClient(pr)
+func (s *Server) waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
+	repo, client, err := s.buildJenkinsClient(pr)
 	if err != nil {
 		mlog.Error("Error building Jenkins client", mlog.Err(err))
-		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.SetupSpinmintFailedMessage)
+		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.SetupSpinmintFailedMessage)
 		return
 	}
 
@@ -128,23 +128,23 @@ func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
 	defer cancel()
 
-	pr, err = waitForBuild(ctx, client, pr)
+	pr, err = s.waitForBuild(ctx, client, pr)
 	if err != nil {
 		mlog.Error("Error waiting for PR build to finish", mlog.Err(err))
-		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.SetupSpinmintFailedMessage)
+		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.SetupSpinmintFailedMessage)
 		return
 	}
 
 	var instance *ec2.Instance
-	if result := <-Srv.Store.Spinmint().Get(pr.Number, pr.RepoName); result.Err != nil {
+	if result := <-s.Store.Spinmint().Get(pr.Number, pr.RepoName); result.Err != nil {
 		mlog.Error("Unable to get the spinmint information. Will not build the spinmint", mlog.String("pr_error", result.Err.Error()))
 	} else if result.Data == nil {
 		mlog.Error("No spinmint for this PR in the Database. will start a fresh one.")
 		var errInstance error
-		instance, errInstance = setupSpinmint(pr, repo, upgradeServer)
+		instance, errInstance = s.setupSpinmint(pr, repo, upgradeServer)
 		if errInstance != nil {
-			logErrorToMattermost("Unable to set up spinmint for PR %v in %v/%v: %v", pr.Number, pr.RepoOwner, pr.RepoName, errInstance.Error())
-			commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.SetupSpinmintFailedMessage)
+			s.logErrorToMattermost("Unable to set up spinmint for PR %v in %v/%v: %v", pr.Number, pr.RepoOwner, pr.RepoName, errInstance.Error())
+			s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.SetupSpinmintFailedMessage)
 			return
 		}
 		spinmint := &model.Spinmint{
@@ -154,7 +154,7 @@ func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 			Number:     pr.Number,
 			CreatedAt:  time.Now().UTC().Unix(),
 		}
-		storeSpinmintInfo(spinmint)
+		s.storeSpinmintInfo(spinmint)
 	} else {
 		spinmint := result.Data.(*model.Spinmint)
 		instance.InstanceId = aws.String(spinmint.InstanceId)
@@ -162,16 +162,16 @@ func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 
 	mlog.Info("Waiting for instance to come up.")
 	time.Sleep(time.Minute * 2)
-	publicDNS, internalIP := getIPsForInstance(*instance.InstanceId)
+	publicDNS, internalIP := s.getIPsForInstance(*instance.InstanceId)
 
-	if err := updateRoute53Subdomain(*instance.InstanceId, publicDNS, "CREATE"); err != nil {
-		logErrorToMattermost("Unable to set up S3 subdomain for PR %v in %v/%v with instance %v: %v", pr.Number, pr.RepoOwner, pr.RepoName, *instance.InstanceId, err.Error())
-		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.SetupSpinmintFailedMessage)
+	if err := s.updateRoute53Subdomain(*instance.InstanceId, publicDNS, "CREATE"); err != nil {
+		s.logErrorToMattermost("Unable to set up S3 subdomain for PR %v in %v/%v with instance %v: %v", pr.Number, pr.RepoOwner, pr.RepoName, *instance.InstanceId, err.Error())
+		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.SetupSpinmintFailedMessage)
 		return
 	}
 
-	smLink := fmt.Sprintf("%v.%v", *instance.InstanceId, Config.AWSDnsSuffix)
-	if Config.SpinmintsUseHttps {
+	smLink := fmt.Sprintf("%v.%v", *instance.InstanceId, s.Config.AWSDnsSuffix)
+	if s.Config.SpinmintsUseHttps {
 		smLink = "https://" + smLink
 	} else {
 		smLink = "http://" + smLink
@@ -179,23 +179,23 @@ func waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServer bool) {
 
 	var message string
 	if upgradeServer {
-		message = Config.SetupSpinmintUpgradeDoneMessage
+		message = s.Config.SetupSpinmintUpgradeDoneMessage
 	} else {
-		message = Config.SetupSpinmintDoneMessage
+		message = s.Config.SetupSpinmintDoneMessage
 	}
 
 	message = strings.Replace(message, SPINMINT_LINK, smLink, 1)
 	message = strings.Replace(message, INSTANCE_ID, INSTANCE_ID_MESSAGE+*instance.InstanceId, 1)
 	message = strings.Replace(message, INTERNAL_IP, internalIP, 1)
 
-	commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, message)
+	s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, message)
 }
 
-func waitForMobileAppsBuild(pr *model.PullRequest) {
-	repo, client, err := buildJenkinsClient(pr)
+func (s *Server) waitForMobileAppsBuild(pr *model.PullRequest) {
+	repo, client, err := s.buildJenkinsClient(pr)
 	if err != nil {
 		mlog.Error("Error building Jenkins client", mlog.Err(err))
-		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.SetupSpinmintFailedMessage)
+		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.SetupSpinmintFailedMessage)
 		return
 	}
 
@@ -204,10 +204,10 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
 	defer cancel()
 
-	pr, err = waitForBuild(ctx, client, pr)
+	pr, err = s.waitForBuild(ctx, client, pr)
 	if err != nil {
 		mlog.Error("Error waiting for PR build to finish", mlog.Err(err))
-		commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.SetupSpinmintFailedMessage)
+		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.SetupSpinmintFailedMessage)
 		return
 	}
 
@@ -240,7 +240,7 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 			break
 		} else if build.Result == "FAILURE" {
 			mlog.Error("build has status FAILURE aborting.", mlog.Int("build", build.Number), mlog.String("result", build.Result))
-			commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, Config.BuildMobileAppFailedMessage)
+			s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.BuildMobileAppFailedMessage)
 			return
 		} else {
 			mlog.Info("build is running", mlog.Int("build", build.Number), mlog.Bool("building", build.Building))
@@ -249,19 +249,19 @@ func waitForMobileAppsBuild(pr *model.PullRequest) {
 	}
 
 	prNumberStr := fmt.Sprintf("PR-%d", pr.Number)
-	msgMobile := Config.BuildMobileAppDoneMessage
+	msgMobile := s.Config.BuildMobileAppDoneMessage
 	msgMobile = strings.Replace(msgMobile, "PR_NUMBER", prNumberStr, 2)
 	msgMobile = strings.Replace(msgMobile, "ANDROID_APP", prNumberStr, 1)
 	msgMobile = strings.Replace(msgMobile, "IOS_APP", prNumberStr, 1)
-	commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, msgMobile)
+	s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, msgMobile)
 	return
 }
 
 // Returns instance ID of instance created
-func setupSpinmint(pr *model.PullRequest, repo *Repository, upgrade bool) (*ec2.Instance, error) {
+func (s *Server) setupSpinmint(pr *model.PullRequest, repo *Repository, upgrade bool) (*ec2.Instance, error) {
 	mlog.Info("Setting up spinmint for PR", mlog.Int("pr", pr.Number))
 
-	svc := ec2.New(session.New(), Config.GetAwsConfig())
+	svc := ec2.New(session.New(), s.GetAwsConfig())
 
 	var setupScript string
 	if upgrade {
@@ -288,13 +288,13 @@ func setupSpinmint(pr *model.PullRequest, repo *Repository, upgrade bool) (*ec2.
 
 	var one int64 = 1
 	params := &ec2.RunInstancesInput{
-		ImageId:          &Config.AWSImageId,
+		ImageId:          &s.Config.AWSImageId,
 		MaxCount:         &one,
 		MinCount:         &one,
-		InstanceType:     &Config.AWSInstanceType,
+		InstanceType:     &s.Config.AWSInstanceType,
 		UserData:         &sdata,
-		SecurityGroupIds: []*string{&Config.AWSSecurityGroup},
-		SubnetId:         &Config.AWSSubNetId,
+		SecurityGroupIds: []*string{&s.Config.AWSSecurityGroup},
+		SubnetId:         &s.Config.AWSSubNetId,
 	}
 
 	resp, err := svc.RunInstances(params)
@@ -332,10 +332,10 @@ func setupSpinmint(pr *model.PullRequest, repo *Repository, upgrade bool) (*ec2.
 	return resp.Instances[0], nil
 }
 
-func destroySpinmint(pr *model.PullRequest, instanceID string) {
+func (s *Server) destroySpinmint(pr *model.PullRequest, instanceID string) {
 	mlog.Info("Destroying spinmint for PR", mlog.String("instance", instanceID), mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName))
 
-	svc := ec2.New(session.New(), Config.GetAwsConfig())
+	svc := ec2.New(session.New(), s.GetAwsConfig())
 
 	params := &ec2.TerminateInstancesInput{
 		InstanceIds: []*string{
@@ -350,18 +350,17 @@ func destroySpinmint(pr *model.PullRequest, instanceID string) {
 	}
 
 	// Remove route53 entry
-	err = updateRoute53Subdomain(instanceID, "", "DELETE")
+	err = s.updateRoute53Subdomain(instanceID, "", "DELETE")
 	if err != nil {
 		mlog.Error("Error removing the Route53 entry", mlog.Err(err))
 		return
 	}
 
-	// Remove from the local db
-	removeTestServerFromDB(instanceID)
+	s.removeTestServerFromDB(instanceID)
 }
 
-func getIPsForInstance(instance string) (publicIP string, privateIP string) {
-	svc := ec2.New(session.New(), Config.GetAwsConfig())
+func (s *Server) getIPsForInstance(instance string) (publicIP string, privateIP string) {
+	svc := ec2.New(session.New(), s.GetAwsConfig())
 	params := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{
 			&instance,
@@ -376,13 +375,13 @@ func getIPsForInstance(instance string) (publicIP string, privateIP string) {
 	return *resp.Reservations[0].Instances[0].PublicIpAddress, *resp.Reservations[0].Instances[0].PrivateIpAddress
 }
 
-func updateRoute53Subdomain(name, target, action string) error {
-	svc := route53.New(session.New(), Config.GetAwsConfig())
-	domainName := fmt.Sprintf("%v.%v", name, Config.AWSDnsSuffix)
+func (s *Server) updateRoute53Subdomain(name, target, action string) error {
+	svc := route53.New(session.New(), s.GetAwsConfig())
+	domainName := fmt.Sprintf("%v.%v", name, s.Config.AWSDnsSuffix)
 
 	targetServer := target
 	if target == "" && action == "DELETE" {
-		targetServer, _ = getIPsForInstance(name)
+		targetServer, _ = s.getIPsForInstance(name)
 	}
 
 	params := &route53.ChangeResourceRecordSetsInput{
@@ -403,7 +402,7 @@ func updateRoute53Subdomain(name, target, action string) error {
 				},
 			},
 		},
-		HostedZoneId: &Config.AWSHostedZoneId,
+		HostedZoneId: &s.Config.AWSHostedZoneId,
 	}
 
 	_, err := svc.ChangeResourceRecordSets(params)
@@ -415,10 +414,10 @@ func updateRoute53Subdomain(name, target, action string) error {
 }
 
 // CheckTestServerLifeTime checks the age of the test server and kills if reach the limit
-func CheckTestServerLifeTime() {
+func (s *Server) CheckTestServerLifeTime() {
 	mlog.Info("Checking Test Server lifetime...")
 	testServers := []*model.Spinmint{}
-	if result := <-Srv.Store.Spinmint().List(); result.Err != nil {
+	if result := <-s.Store.Spinmint().List(); result.Err != nil {
 		mlog.Error("Unable to get updated PR while waiting for test server", mlog.String("testServer_error", result.Err.Error()))
 	} else {
 		testServers = result.Data.([]*model.Spinmint)
@@ -435,12 +434,8 @@ func CheckTestServerLifeTime() {
 				RepoName:  testServer.RepoName,
 				Number:    testServer.Number,
 			}
-			if strings.Contains(testServer.InstanceId, "i-") {
-				go destroySpinmint(pr, testServer.InstanceId)
-			} else {
-				go handleDestroySpinWick(pr, testServer.InstanceId)
-			}
-			removeTestServerFromDB(testServer.InstanceId)
+			go s.destroySpinmint(pr, testServer.InstanceId)
+			s.removeTestServerFromDB(testServer.InstanceId)
 			commentOnIssue(testServer.RepoOwner, testServer.RepoName, testServer.Number, Config.DestroyedExpirationSpinmintMessage)
 		}
 	}
@@ -448,18 +443,18 @@ func CheckTestServerLifeTime() {
 	mlog.Info("Done checking Test Server lifetime.")
 }
 
-func storeSpinmintInfo(spinmint *model.Spinmint) {
-	if result := <-Srv.Store.Spinmint().Save(spinmint); result.Err != nil {
+func (s *Server) storeSpinmintInfo(spinmint *model.Spinmint) {
+	if result := <-s.Store.Spinmint().Save(spinmint); result.Err != nil {
 		mlog.Error(result.Err.Error())
 	}
 }
 
-func removeTestServerFromDB(instanceId string) {
-	if result := <-Srv.Store.Spinmint().Delete(instanceId); result.Err != nil {
+func (s *Server) removeTestServerFromDB(instanceId string) {
+	if result := <-s.Store.Spinmint().Delete(instanceId); result.Err != nil {
 		mlog.Error(result.Err.Error())
 	}
 }
 
-func isSpinMintLabel(label string) bool {
-	return label == Config.SetupSpinmintTag || label == Config.SetupSpinmintUpgradeTag
+func (s *Server) isSpinMintLabel(label string) bool {
+	return label == s.Config.SetupSpinmintTag || label == s.Config.SetupSpinmintUpgradeTag
 }

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -16,66 +16,12 @@ import (
 
 	"time"
 
+	"github.com/mattermost/mattermost-mattermod/cloud"
 	"github.com/mattermost/mattermost-mattermod/model"
 	"github.com/mattermost/mattermost-server/mlog"
 	mattermostModel "github.com/mattermost/mattermost-server/model"
 	"github.com/pkg/errors"
 )
-
-// The following structs are copied from the mattermost-cloud repo to allow
-// mattermod to interact with provisioning servers.
-//
-// TODO: consider moving the structs in mattermost-cloud for these models out
-// of the /internal directory so that they can be vendored and imported here.
-// When doing this, we should start using semver in the mattermost-cloud repo.
-
-// CreateClusterRequest specifies the parameters for a new cluster.
-type CreateClusterRequest struct {
-	Provider string
-	Size     string
-	Zones    []string
-}
-
-// Cluster represents a Kubernetes cluster.
-type Cluster struct {
-	ID                  string
-	Provider            string
-	Provisioner         string
-	ProviderMetadata    []byte `json:",omitempty"`
-	ProvisionerMetadata []byte `json:",omitempty"`
-	AllowInstallations  bool
-	Size                string
-	State               string
-	CreateAt            int64
-	DeleteAt            int64
-	LockAcquiredBy      *string
-	LockAcquiredAt      int64
-}
-
-// CreateInstallationRequest specifies the parameters for a new installation.
-type CreateInstallationRequest struct {
-	OwnerID  string
-	Version  string
-	DNS      string
-	Size     string
-	Affinity string
-}
-
-// Installation represents a Mattermost installation.
-type Installation struct {
-	ID             string
-	OwnerID        string
-	Version        string
-	DNS            string
-	Size           string
-	Affinity       string
-	GroupID        *string
-	State          string
-	CreateAt       int64
-	DeleteAt       int64
-	LockAcquiredBy *string
-	LockAcquiredAt int64
-}
 
 func (s *Server) handleCreateSpinWick(pr *model.PullRequest, size string) {
 	installationID, sendMattermostLog, err := s.createSpinWick(pr, size)
@@ -88,36 +34,25 @@ func (s *Server) handleCreateSpinWick(pr *model.PullRequest, size string) {
 			}
 			s.logPrettyErrorToMattermost("[ SpinWick ] Creation Failed", pr, err, additionalFields)
 		}
-
-		return
-	}
-
-	if installationID != "" {
-		s.storeSpinmintInfo(&model.Spinmint{
-			InstanceId: installationID,
-			RepoOwner:  pr.RepoOwner,
-			RepoName:   pr.RepoName,
-			Number:     pr.Number,
-			CreatedAt:  time.Now().UTC().Unix(),
-		})
 	}
 }
 
-// createSpinWick creates a SpinWick and returns an error as well as a bool
-// indicating if the error should be logged to Mattermost.
+// createSpinwick creates a SpinWick with the following behavior:
+// - no cloud installation found = installation is created
+// - cloud installation found = actual ID string and no error
+// - any errors = error is returned
 func (s *Server) createSpinWick(pr *model.PullRequest, size string) (string, bool, error) {
 	installationID := "n/a"
-
-	result := <-s.Store.Spinmint().Get(pr.Number, pr.RepoName)
-	if result.Err != nil {
-		return installationID, true, errors.Wrap(result.Err, "unable to get the SpinWick information from database")
+	ownerID := makeSpinWickID(pr.RepoName, pr.Number)
+	id, err := cloud.GetInstallationIDFromOwnerID(s.Config.ProvisionerServer, ownerID)
+	if err != nil {
+		return installationID, true, err
 	}
-	if result.Data != nil {
-		mlog.Info("PR already has a SpinWick created", mlog.String("repo_name", pr.RepoName), mlog.Int("pr", pr.Number))
-		return installationID, false, nil
+	if id != "" {
+		return id, false, nil
 	}
 
-	mlog.Info("No SpinWick for this PR in the database. Creating a new one.")
+	mlog.Info("No SpinWick found for this PR. Creating a new one.")
 
 	_, client, err := s.buildJenkinsClient(pr)
 	if err != nil {
@@ -134,25 +69,12 @@ func (s *Server) createSpinWick(pr *model.PullRequest, size string) (string, boo
 		return installationID, false, errors.Wrap(err, "error waiting for PR build to finish")
 	}
 
-	// Check the mattermod store again just in case a separate process created
-	// a SpinWick while we waited for the build to finish.
-	//
-	// TODO: this should be improved in the future.
-	result = <-s.Store.Spinmint().Get(pr.Number, pr.RepoName)
-	if result.Err != nil {
-		return installationID, true, errors.Wrap(result.Err, "unable to get the SpinWick information from database")
-	}
-	if result.Data != nil {
-		return installationID, true, errors.New("More than a single process was trying to create a SpinWick")
-	}
-
 	mlog.Info("Provisioning Server - Installation request")
 
-	spinwickID := makeSpinWickID(pr.RepoName, pr.Number)
-	installationRequest := CreateInstallationRequest{
-		OwnerID:  spinwickID,
+	installationRequest := cloud.CreateInstallationRequest{
+		OwnerID:  ownerID,
 		Version:  pr.Sha[0:7],
-		DNS:      fmt.Sprintf("%s.%s", spinwickID, s.Config.DNSNameTestServer),
+		DNS:      fmt.Sprintf("%s.%s", ownerID, s.Config.DNSNameTestServer),
 		Size:     size,
 		Affinity: "multitenant",
 	}
@@ -169,7 +91,7 @@ func (s *Server) createSpinWick(pr *model.PullRequest, size string) (string, boo
 	}
 	defer respReqInstallation.Body.Close()
 
-	var installation Installation
+	var installation cloud.Installation
 	err = json.NewDecoder(respReqInstallation.Body).Decode(&installation)
 	if err != nil && err != io.EOF {
 		return installationID, true, errors.Wrap(err, "error decoding installation")
@@ -177,39 +99,23 @@ func (s *Server) createSpinWick(pr *model.PullRequest, size string) (string, boo
 	installationID = installation.ID
 	mlog.Info("Provisioner Server - installation request", mlog.String("InstallationID", installationID))
 
-	time.Sleep(3 * time.Second)
-	// Get the installaion to check if the state is creation-no-compatible-clusters
-	// if is that state we need to requst a new k8s cluster
-	// TODO:
-	// There is no garauntee that the installation has been worked on yet. We
-	// may have to wait longer for it to enter the creation-no-compatible-clusters
-	// state.
-	url = fmt.Sprintf("%s/api/installation/%s", s.Config.ProvisionerServer, installationID)
-	resp, err := makeRequest("GET", url, nil)
-	if err != nil {
-		return installationID, true, errors.Wrap(err, "error getting the mattermost installation")
-	}
-	defer resp.Body.Close()
-
-	err = json.NewDecoder(resp.Body).Decode(&installation)
-	if err != nil && err != io.EOF {
-		return installationID, true, errors.Wrap(err, "error decoding installation")
-	}
-	if installation.State == "creation-no-compatible-clusters" {
-		err = s.requestK8sClusterCreation(pr)
-		if err != nil {
-			return installationID, true, errors.Wrap(err, "unable to create a new cluster to accommodate the installation")
-		}
-	}
-
 	wait := 480
 	mlog.Info("Waiting up to 480 seconds for the mattermost installation to complete...")
 	ctx, cancel = context.WithTimeout(context.Background(), time.Duration(wait)*time.Second)
 	defer cancel()
-	err = s.waitMattermostInstallation(ctx, pr, installationID, false)
+	err = s.waitForMattermostInstallationStable(ctx, pr, installationID)
 	if err != nil {
 		return installationID, true, errors.Wrap(err, "error waiting for installation to become stable")
 	}
+
+	spinwickURL := fmt.Sprintf("https://%s.%s", makeSpinWickID(pr.RepoName, pr.Number), s.Config.DNSNameTestServer)
+	err = s.initializeMattermostTestServer(spinwickURL, pr.Number)
+	if err != nil {
+		return installationID, true, errors.Wrap(err, "failed to initialize the SpinWick")
+	}
+	userTable := "| Account Type | Username | Password |\n|---|---|---|\n| Admin | sysadmin | Sys@dmin123 |\n| User | user-1 | User-1@123 |"
+	msg := fmt.Sprintf("Mattermost test server created! :tada:\n\nAccess here: %s\n\n%s", spinwickURL, userTable)
+	s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, msg)
 
 	return installationID, false, nil
 }
@@ -228,35 +134,24 @@ func (s *Server) handleUpdateSpinWick(pr *model.PullRequest) {
 	}
 }
 
-// udpateSpinWick updates a SpinWick and returns an error as well as a bool
-// indicating if the error should be logged to Mattermost.
+// updateSpinWick updates a SpinWick with the following behavior:
+// - no cloud installation found = error is returned
+// - cloud installation found and updated = actual ID string and no error
+// - any errors = error is returned
 func (s *Server) updateSpinWick(pr *model.PullRequest) (string, bool, error) {
 	installationID := "n/a"
-	foundLabel := false
-	for _, label := range pr.Labels {
-		if s.isSpinWickLabel(label) {
-			mlog.Info("PR has a SpinWick label; proceeding with upgrade", mlog.Int("pr", pr.Number))
-			foundLabel = true
-			break
-		}
-	}
 
-	if !foundLabel {
-		return installationID, false, nil
+	ownerID := makeSpinWickID(pr.RepoName, pr.Number)
+	id, err := cloud.GetInstallationIDFromOwnerID(s.Config.ProvisionerServer, ownerID)
+	if err != nil {
+		return installationID, true, err
 	}
+	if id == "" {
+		return installationID, true, errors.New("no installation found matching this PR")
+	}
+	installationID = id
 
-	result := <-s.Store.Spinmint().Get(pr.Number, pr.RepoName)
-	if result.Err != nil {
-		return installationID, true, errors.Wrap(result.Err, "unable to get SpinWick information from the database")
-	}
-	if result.Data == nil {
-		return installationID, true, errors.New("no SpinWick database information found")
-	}
-	installationID = result.Data.(*model.Spinmint).InstanceId
-
-	// TODO: add a new column in the db to get the previous job and wait for the new one start
-	// for now will sleep some time
-	mlog.Info("Sleeping a bit to wait for the build process start", mlog.Int("pr", pr.Number), mlog.String("sha", pr.Sha))
+	mlog.Info("Sleeping a bit to wait for the build process to start", mlog.Int("pr", pr.Number), mlog.String("sha", pr.Sha))
 	time.Sleep(60 * time.Second)
 
 	wait := 480
@@ -269,12 +164,6 @@ func (s *Server) updateSpinWick(pr *model.PullRequest) (string, bool, error) {
 	buildLink, err := s.checkBuildLink(ctx, pr)
 	if err != nil || buildLink == "" {
 		return installationID, true, errors.Wrap(err, "error waiting for build link")
-	}
-	mlog.Info("Build Link updated", mlog.String("buildLink", buildLink), mlog.String("OldBuildLink", pr.BuildLink))
-	pr.BuildLink = buildLink
-	result = <-s.Store.PullRequest().Save(pr)
-	if result.Err != nil {
-		return installationID, true, errors.Wrap(result.Err, "unable to save updated PR to the database")
 	}
 
 	s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "New commit detected. SpinWick upgrade will occur after the build is successful.")
@@ -294,7 +183,7 @@ func (s *Server) updateSpinWick(pr *model.PullRequest) (string, bool, error) {
 		return installationID, false, errors.Wrap(err, "error waiting for PR build to finish")
 	}
 
-	// TODO: remove this when we starting building the docker image in the sam build pipeline
+	// TODO: remove this when we starting building the docker image in the same build pipeline
 	time.Sleep(60 * time.Second)
 
 	mlog.Info("Provisioning Server - Upgrade request", mlog.String("SHA", pr.Sha))
@@ -314,18 +203,20 @@ func (s *Server) updateSpinWick(pr *model.PullRequest) (string, bool, error) {
 	mlog.Info("Waiting for mattermost installation to become stable", mlog.Int("wait_seconds", wait))
 	ctx, cancel = context.WithTimeout(context.Background(), time.Duration(wait)*time.Second)
 	defer cancel()
-	err = s.waitMattermostInstallation(ctx, pr, installationID, true)
+	err = s.waitForMattermostInstallationStable(ctx, pr, installationID)
 	if err != nil {
 		return installationID, true, errors.Wrap(err, "encountered error waiting for installation to become stable")
 	}
 
+	mmURL := fmt.Sprintf("https://%s.%s", makeSpinWickID(pr.RepoName, pr.Number), s.Config.DNSNameTestServer)
+	msg := fmt.Sprintf("Mattermost test server updated!\n\nAccess here: %s", mmURL)
+	s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, msg)
+
 	return installationID, false, nil
 }
 
-func (s *Server) handleDestroySpinWick(pr *model.PullRequest, installationID string) {
-	mlog.Info("Destroying SpinWick", mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName), mlog.String("installation_id", installationID))
-
-	sendMattermostLog, err := s.destroyMMInstallation(installationID)
+func (s *Server) handleDestroySpinWick(pr *model.PullRequest) {
+	installationID, sendMattermostLog, err := s.destroySpinWick(pr)
 	if err != nil {
 		mlog.Error("Failed to delete Mattermost installation", mlog.Err(err), mlog.String("repo_name", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("installation_id", installationID))
 		if sendMattermostLog {
@@ -335,21 +226,47 @@ func (s *Server) handleDestroySpinWick(pr *model.PullRequest, installationID str
 			s.logPrettyErrorToMattermost("[ SpinWick ] Destroy Failed", pr, err, additionalFields)
 		}
 	}
-
-	s.removeTestServerFromDB(installationID)
 }
 
-// destroyMMInstallation destroys a SpinWick and returns an error as well as a bool
-// indicating if the error should be logged to Mattermost.
-func (s *Server) destroyMMInstallation(instanceClusterID string) (bool, error) {
-	url := fmt.Sprintf("%s/api/installation/%s", s.Config.ProvisionerServer, instanceClusterID)
+// destroySpinwick destroys a SpinWick with the following behavior:
+// - no cloud installation found = empty ID string and no error
+// - cloud installation found and deleted = actual ID string and no error
+// - any errors = error is returned
+func (s *Server) destroySpinWick(pr *model.PullRequest) (string, bool, error) {
+	installationID := "n/a"
+
+	ownerID := makeSpinWickID(pr.RepoName, pr.Number)
+	id, err := cloud.GetInstallationIDFromOwnerID(s.Config.ProvisionerServer, ownerID)
+	if err != nil {
+		return installationID, true, err
+	}
+	if id == "" {
+		return installationID, false, nil
+	}
+	installationID = id
+
+	mlog.Info("Destroying SpinWick", mlog.Int("pr", pr.Number), mlog.String("repo_owner", pr.RepoOwner), mlog.String("repo_name", pr.RepoName), mlog.String("installation_id", installationID))
+
+	url := fmt.Sprintf("%s/api/installation/%s", s.Config.ProvisionerServer, installationID)
 	resp, err := makeRequest("DELETE", url, nil)
 	if err != nil {
-		return true, errors.Wrap(err, "unable to make installation delete request to provisioning server")
+		return installationID, true, errors.Wrap(err, "unable to make installation delete request to provisioning server")
 	}
 	defer resp.Body.Close()
 
-	return false, nil
+	// Old comments created by Mattermod user will be deleted here.
+	s.commentLock.Lock()
+	defer s.commentLock.Unlock()
+
+	comments, _, err := NewGithubClient(s.Config.GithubAccessToken).Issues.ListComments(context.Background(), pr.RepoOwner, pr.RepoName, pr.Number, nil)
+	if err != nil {
+		return installationID, true, errors.Wrap(err, "unable to get list of old comments")
+	}
+	s.removeOldComments(comments, pr)
+
+	s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.DestroyedSpinmintMessage)
+
+	return installationID, false, nil
 }
 
 func (s *Server) checkBuildLink(ctx context.Context, pr *model.PullRequest) (string, error) {
@@ -388,49 +305,33 @@ func (s *Server) checkBuildLink(ctx context.Context, pr *model.PullRequest) (str
 	}
 }
 
-func (s *Server) waitMattermostInstallation(ctx context.Context, pr *model.PullRequest, installationRequestID string, upgrade bool) error {
+func (s *Server) waitForMattermostInstallationStable(ctx context.Context, pr *model.PullRequest, installationID string) error {
 	for {
-		url := fmt.Sprintf("%s/api/installation/%s", s.Config.ProvisionerServer, installationRequestID)
-		resp, err := makeRequest("GET", url, nil)
+		installation, err := cloud.GetInstallation(s.Config.ProvisionerServer, installationID)
 		if err != nil {
-			mlog.Error("Error making the post request to create the mm installation", mlog.Err(err))
 			return err
 		}
-		defer resp.Body.Close()
-		var installationRequest Installation
-		err = json.NewDecoder(resp.Body).Decode(&installationRequest)
-		if err != nil && err != io.EOF {
-			mlog.Error("Error decoding installation", mlog.Err(err))
-			return fmt.Errorf("Error decoding installation: %s", err)
-		}
-		if installationRequest.State == "stable" {
-			mmURL := fmt.Sprintf("https://%s.%s", makeSpinWickID(pr.RepoName, pr.Number), s.Config.DNSNameTestServer)
-			if !upgrade {
-				userErr := s.initializeMattermostTestServer(mmURL, pr.Number)
-				if userErr != nil {
-					s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to create mattermost installation.")
-					s.destroyMMInstallation(installationRequest.ID)
-					return nil
-				}
-				userTable := "| Account Type | Username | Password |\n|---|---|---|\n| Admin | sysadmin | Sys@dmin123 |\n| User | user-1 | User-1@123 |"
-				msg := fmt.Sprintf("Mattermost test server created! :tada:\n\nAccess here: %s\n\n%s", mmURL, userTable)
-				s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, msg)
-			} else {
-				msg := fmt.Sprintf("Mattermost test server updated!\n\nAccess here: %s", mmURL)
-				s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, msg)
-			}
+
+		switch installation.State {
+		case "stable":
 			return nil
-		} else if installationRequest.State == "creation-failed" {
-			s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to create mattermost installation.")
-			s.destroyMMInstallation(installationRequest.ID)
-			return fmt.Errorf("error creating mattermost installation")
+		case "creation-failed":
+			return errors.New("the installation creation failed")
+		case "creation-no-compatible-clusters":
+			err = s.requestK8sClusterCreation(pr)
+			if err != nil {
+				return errors.Wrap(err, "unable to create a new cluster to accommodate the installation")
+			}
+			// This sleep is a bit hacky, but is intended to ensure that the
+			// installation has time to be worked on before we check its state
+			// again so we don't create another cluster needlessly.
+			time.Sleep(30 * time.Second)
 		}
-		mlog.Info("Provisioner Server - installation request creating... sleep", mlog.String("InstallationID", installationRequest.ID), mlog.String("State", installationRequest.State))
+
+		mlog.Info("Waiting for installation to stabilize", mlog.String("installation_id", installation.ID), mlog.String("state", installation.State))
 		select {
 		case <-ctx.Done():
-			s.destroyMMInstallation(installationRequest.ID)
-			s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Timed out waiting for the mattermost installation. Please check the logs.")
-			return fmt.Errorf("timed out waiting for the mattermost installation complete. requesting the deletion")
+			return errors.New("timed out waiting for the mattermost installation to stabilize")
 		case <-time.After(10 * time.Second):
 		}
 	}
@@ -446,7 +347,7 @@ func (s *Server) waitK8sCluster(ctx context.Context, pr *model.PullRequest, clus
 		}
 		defer resp.Body.Close()
 
-		var clusterRequest Cluster
+		var clusterRequest cloud.Cluster
 		err = json.NewDecoder(resp.Body).Decode(&clusterRequest)
 		if err != nil && err != io.EOF {
 			mlog.Error("Error decoding cluster response", mlog.Err(err))
@@ -486,19 +387,19 @@ func makeRequest(method, url string, payload io.Reader) (*http.Response, error) 
 }
 
 func (s *Server) initializeMattermostTestServer(mmURL string, prNumber int) error {
-	mlog.Info("Will check if can ping the new DNS otherwise will wait for the DNS propagation for 5 minutes")
+	mlog.Info("Initializing Mattermost installation")
+
 	wait := 300
+	mlog.Info("Waiting up to 300 seconds for DNS to propagate")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(wait)*time.Second)
 	defer cancel()
 
 	mmHost, _ := url.Parse(mmURL)
 	err := checkDNS(ctx, fmt.Sprintf("%s:443", mmHost.Host))
 	if err != nil {
-		mlog.Info("URL not accessible")
-		return err
+		return errors.Wrap(err, "timed out waiting for DNS to propagate for installation")
 	}
 
-	mlog.Info("Will create the initial user")
 	client := mattermostModel.NewAPIv4Client(mmURL)
 
 	//check if Mattermost is available
@@ -506,7 +407,7 @@ func (s *Server) initializeMattermostTestServer(mmURL string, prNumber int) erro
 	defer cancel()
 	err = checkMMPing(ctx, client)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get mattermost ping response")
 	}
 
 	user := &mattermostModel.User{
@@ -516,21 +417,15 @@ func (s *Server) initializeMattermostTestServer(mmURL string, prNumber int) erro
 	}
 	_, response := client.CreateUser(user)
 	if response.StatusCode != 201 {
-		mlog.Error("Error creating the initial user", mlog.Int("StatusCode", response.StatusCode), mlog.String("Message", response.Error.Message))
-		return fmt.Errorf(response.Error.Message)
+		return fmt.Errorf("error creating the initial mattermost user: status code = %d, message = %s", response.StatusCode, response.Error.Message)
 	}
-	mlog.Info("Done the creation of the initial user")
 
-	mlog.Info("Logging into MM")
 	client.Logout()
 	userLogged, response := client.Login("sysadmin", "Sys@dmin123")
 	if response.StatusCode != 200 {
-		mlog.Error("Error logging with the initial user", mlog.Int("StatusCode", response.StatusCode), mlog.String("Message", response.Error.Message))
-		return fmt.Errorf(response.Error.Message)
+		return fmt.Errorf("error logging in with initial mattermost user: status code = %d, message = %s", response.StatusCode, response.Error.Message)
 	}
-	mlog.Info("Done logging into MM")
 
-	mlog.Info("Creating new Team")
 	teamName := fmt.Sprintf("pr%d", prNumber)
 	team := &mattermostModel.Team{
 		Name:        teamName,
@@ -539,16 +434,14 @@ func (s *Server) initializeMattermostTestServer(mmURL string, prNumber int) erro
 	}
 	firstTeam, response := client.CreateTeam(team)
 	if response.StatusCode != 201 {
-		mlog.Error("Error creating the initial team", mlog.Int("StatusCode", response.StatusCode))
+		return fmt.Errorf("error creating the initial team: status code = %d, message = %s", response.StatusCode, response.Error.Message)
 	}
-	mlog.Info("Done creating new Team and will update the config")
 
 	_, response = client.AddTeamMember(firstTeam.Id, userLogged.Id)
 	if response.StatusCode != 201 {
-		mlog.Error("Error adding sysadmin to the initial team", mlog.Int("StatusCode", response.StatusCode))
+		return fmt.Errorf("error adding sysadmin to the initial team: status code = %d, message = %s", response.StatusCode, response.Error.Message)
 	}
 
-	// Create test user-1
 	testUser := &mattermostModel.User{
 		Username: "user-1",
 		Email:    "user-1@example.mattermost.com",
@@ -556,17 +449,16 @@ func (s *Server) initializeMattermostTestServer(mmURL string, prNumber int) erro
 	}
 	testUser, response = client.CreateUser(testUser)
 	if response.StatusCode != 201 {
-		mlog.Error("Error creating the initial test user", mlog.Int("StatusCode", response.StatusCode), mlog.String("Message", response.Error.Message))
+		return fmt.Errorf("error creating the standard test user: status code = %d, message = %s", response.StatusCode, response.Error.Message)
 	}
 	_, response = client.AddTeamMember(firstTeam.Id, testUser.Id)
 	if response.StatusCode != 201 {
-		mlog.Error("Error adding test user to the initial team", mlog.Int("StatusCode", response.StatusCode))
+		return fmt.Errorf("error adding standard test user to the initial team: status code = %d, message = %s", response.StatusCode, response.Error.Message)
 	}
 
 	config, response := client.GetConfig()
 	if response.StatusCode != 200 {
-		mlog.Error("Error getting the config ", mlog.Int("StatusCode", response.StatusCode), mlog.String("Message", response.Error.Message))
-		return fmt.Errorf(response.Error.Message)
+		return fmt.Errorf("error getting mattermost config: status code = %d, message = %s", response.StatusCode, response.Error.Message)
 	}
 
 	config.TeamSettings.EnableOpenServer = NewBool(true)
@@ -602,11 +494,10 @@ func (s *Server) initializeMattermostTestServer(mmURL string, prNumber int) erro
 	// UpdateConfig
 	_, response = client.UpdateConfig(config)
 	if response.StatusCode != 200 {
-		mlog.Error("Error setting the config ", mlog.Int("StatusCode", response.StatusCode), mlog.String("Message", response.Error.Message))
-		return fmt.Errorf(response.Error.Message)
+		return fmt.Errorf("error updating mattermost config: status code = %d, message = %s", response.StatusCode, response.Error.Message)
 	}
 
-	mlog.Info("Done update the s.Config. All good.")
+	mlog.Info("Mattermost configuration complete")
 
 	return nil
 }
@@ -617,7 +508,7 @@ func (s *Server) requestK8sClusterCreation(pr *model.PullRequest) error {
 	url := fmt.Sprintf("%s/api/clusters", s.Config.ProvisionerServer)
 	s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, "Please wait while a new kubernetes cluster is created for your SpinWick")
 
-	clusterRequest := CreateClusterRequest{
+	clusterRequest := cloud.CreateClusterRequest{
 		Size: "SizeAlef1000",
 	}
 	b, err := json.Marshal(clusterRequest)
@@ -633,7 +524,7 @@ func (s *Server) requestK8sClusterCreation(pr *model.PullRequest) error {
 	}
 	defer respReqCluster.Body.Close()
 
-	var cluster Cluster
+	var cluster cloud.Cluster
 	err = json.NewDecoder(respReqCluster.Body).Decode(&cluster)
 	if err != nil && err != io.EOF {
 		mlog.Error("Error decoding cluster", mlog.Err(err))
@@ -654,15 +545,13 @@ func checkDNS(ctx context.Context, url string) error {
 		timeout := time.Duration(2 * time.Second)
 		_, err := net.DialTimeout("tcp", url, timeout)
 		if err == nil {
-			mlog.Debug("URL reachable", mlog.String("URL", url))
 			return nil
 		}
+
 		select {
 		case <-ctx.Done():
-			mlog.Error("Timeout while checking the URL. URL not reachabled", mlog.String("URL", url))
-			return fmt.Errorf("Timeout while checking the URL. URL not reachabled")
+			return fmt.Errorf("timed out waiting for %s to become reachable", url)
 		case <-time.After(10 * time.Second):
-			mlog.Debug("not reachabled, will sleep 10 seconds", mlog.String("URL", url))
 		}
 	}
 }
@@ -673,12 +562,11 @@ func checkMMPing(ctx context.Context, client *mattermostModel.Client4) error {
 		if response.StatusCode == 200 && status == "OK" {
 			return nil
 		}
+
 		select {
 		case <-ctx.Done():
-			mlog.Error("Timeout while checking mattermost")
-			return fmt.Errorf("Timeout while checking mattermost")
+			return errors.New("timed out waiting for ok response")
 		case <-time.After(10 * time.Second):
-			mlog.Debug("cannot get the mattermost ping, waiting a bit more")
 		}
 	}
 }
@@ -689,4 +577,14 @@ func makeSpinWickID(repoName string, prNumber int) string {
 
 func (s *Server) isSpinWickLabel(label string) bool {
 	return label == s.Config.SetupSpinWick || label == s.Config.SetupSpinWickHA
+}
+
+func (s *Server) isSpinWickLabelInLabels(labels []string) bool {
+	for _, label := range labels {
+		if s.isSpinWickLabel(label) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/server/spinwick_test.go
+++ b/server/spinwick_test.go
@@ -52,3 +52,77 @@ func TestIsSpinWickLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSpinWickLabelInLabels(t *testing.T) {
+	spinwickLabel := "spinwick"
+	spinwickHALabel := "spinwick ha"
+	s := &Server{
+		Config: &ServerConfig{
+			SetupSpinWick:   spinwickLabel,
+			SetupSpinWickHA: spinwickHALabel,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		labels   []string
+		expected bool
+	}{
+		{
+			"spinwick label",
+			[]string{
+				spinwickLabel,
+			},
+			true,
+		}, {
+			"spinwick and ha label",
+			[]string{
+				spinwickLabel,
+				spinwickHALabel,
+			},
+			true,
+		}, {
+			"spinwick label and others",
+			[]string{
+				spinwickLabel,
+				"label1",
+				"label2",
+			},
+			true,
+		}, {
+			"spinwick label and more others",
+			[]string{
+				"label0",
+				spinwickLabel,
+				"label1",
+				"label2",
+			},
+			true,
+		}, {
+			"spinwick ha label and others",
+			[]string{
+				spinwickHALabel,
+				"label1",
+				"label2",
+			},
+			true,
+		}, {
+			"not a spinwick label",
+			[]string{
+				"label1",
+				"label2",
+			},
+			false,
+		}, {
+			"empty",
+			[]string{},
+			false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, s.isSpinWickLabelInLabels(tc.labels))
+		})
+	}
+}

--- a/server/spinwick_test.go
+++ b/server/spinwick_test.go
@@ -30,8 +30,12 @@ func TestMakeSpinWickID(t *testing.T) {
 func TestIsSpinWickLabel(t *testing.T) {
 	spinwickLabel := "spinwick"
 	spinwickHALabel := "spinwick ha"
-	Config.SetupSpinWick = spinwickLabel
-	Config.SetupSpinWickHA = spinwickHALabel
+	s := &Server{
+		Config: &ServerConfig{
+			SetupSpinWick:   spinwickLabel,
+			SetupSpinWickHA: spinwickHALabel,
+		},
+	}
 
 	tests := []struct {
 		label    string
@@ -44,7 +48,7 @@ func TestIsSpinWickLabel(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.label, func(t *testing.T) {
-			require.Equal(t, tc.expected, isSpinWickLabel(tc.label))
+			require.Equal(t, tc.expected, s.isSpinWickLabel(tc.label))
 		})
 	}
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -147,11 +147,12 @@ func (s *Server) logPrettyErrorToMattermost(msg string, pr *model.PullRequest, e
 
 	mlog.Debug("Sending Mattermost message", mlog.String("message", msg))
 
-	fullMessage := fmt.Sprintf("%s\n---\nError: %s\nRepository: %s/%s\nPull Request: %d [ %s ]\n",
+	fullMessage := fmt.Sprintf("%s\n---\nError: %s\nRepository: %s/%s\nPull Request: %d [ status=%s ]\nURL: %s\n",
 		msg,
 		err,
 		pr.RepoOwner, pr.RepoName,
 		pr.Number, pr.State,
+		pr.URL,
 	)
 	for key, value := range additionalFields {
 		fullMessage = fullMessage + fmt.Sprintf("%s: %s\n", key, value)

--- a/server/utils.go
+++ b/server/utils.go
@@ -13,12 +13,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func buildJenkinsClient(pr *model.PullRequest) (*Repository, *jenkins.Jenkins, error) {
-	repo, ok := Config.GetRepository(pr.RepoOwner, pr.RepoName)
+func (s *Server) buildJenkinsClient(pr *model.PullRequest) (*Repository, *jenkins.Jenkins, error) {
+	repo, ok := s.GetRepository(pr.RepoOwner, pr.RepoName)
 	if !ok || repo.JenkinsServer == "" {
 		return repo, nil, errors.New("jenkins server is not configured")
 	}
-	credentials, ok := Config.JenkinsCredentials[repo.JenkinsServer]
+	credentials, ok := s.Config.JenkinsCredentials[repo.JenkinsServer]
 	if !ok {
 		return repo, nil, errors.New("jenkins server credentials are not configured")
 	}
@@ -31,13 +31,13 @@ func buildJenkinsClient(pr *model.PullRequest) (*Repository, *jenkins.Jenkins, e
 	return repo, client, nil
 }
 
-func waitForBuild(ctx context.Context, client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRequest, error) {
+func (s *Server) waitForBuild(ctx context.Context, client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRequest, error) {
 	for {
 		select {
 		case <-ctx.Done():
 			return pr, errors.New("timed out waiting for build to finish")
 		case <-time.After(30 * time.Second):
-			result := <-Srv.Store.PullRequest().Get(pr.RepoOwner, pr.RepoName, pr.Number)
+			result := <-s.Store.PullRequest().Get(pr.RepoOwner, pr.RepoName, pr.Number)
 			if result.Err != nil {
 				return pr, errors.Wrap(result.Err, "unable to get updated PR from Mattermod database")
 			}
@@ -45,7 +45,7 @@ func waitForBuild(ctx context.Context, client *jenkins.Jenkins, pr *model.PullRe
 			// Update the PR in case the build link has changed because of a new commit
 			pr = result.Data.(*model.PullRequest)
 			var err error
-			pr, err = GetUpdateChecks(pr.RepoOwner, pr.RepoName, pr.Number)
+			pr, err = s.GetUpdateChecks(pr.RepoOwner, pr.RepoName, pr.Number)
 			if err != nil {
 				return pr, errors.Wrap(err, "unable to get updated PR from GitHub")
 			}
@@ -119,8 +119,8 @@ func waitForBuild(ctx context.Context, client *jenkins.Jenkins, pr *model.PullRe
 	}
 }
 
-func logErrorToMattermost(msg string, args ...interface{}) {
-	if Config.MattermostWebhookURL == "" {
+func (s *Server) logErrorToMattermost(msg string, args ...interface{}) {
+	if s.Config.MattermostWebhookURL == "" {
 		mlog.Warn("No Mattermost webhook URL set: unable to send message")
 		return
 	}
@@ -128,19 +128,19 @@ func logErrorToMattermost(msg string, args ...interface{}) {
 	webhookMessage := fmt.Sprintf(msg, args...)
 	mlog.Debug("Sending Mattermost message", mlog.String("message", webhookMessage))
 
-	if Config.MattermostWebhookFooter != "" {
-		webhookMessage += "\n---\n" + Config.MattermostWebhookFooter
+	if s.Config.MattermostWebhookFooter != "" {
+		webhookMessage += "\n---\n" + s.Config.MattermostWebhookFooter
 	}
 
 	webhookRequest := &WebhookRequest{Username: "Mattermod", Text: webhookMessage}
 
-	if err := sendToWebhook(webhookRequest, Config.MattermostWebhookURL); err != nil {
+	if err := s.sendToWebhook(webhookRequest, s.Config.MattermostWebhookURL); err != nil {
 		mlog.Error("Unable to post to Mattermost webhook", mlog.Err(err))
 	}
 }
 
-func logPrettyErrorToMattermost(msg string, pr *model.PullRequest, err error, additionalFields map[string]string) {
-	if Config.MattermostWebhookURL == "" {
+func (s *Server) logPrettyErrorToMattermost(msg string, pr *model.PullRequest, err error, additionalFields map[string]string) {
+	if s.Config.MattermostWebhookURL == "" {
 		mlog.Warn("No Mattermost webhook URL set: unable to send message")
 		return
 	}
@@ -156,11 +156,11 @@ func logPrettyErrorToMattermost(msg string, pr *model.PullRequest, err error, ad
 	for key, value := range additionalFields {
 		fullMessage = fullMessage + fmt.Sprintf("%s: %s\n", key, value)
 	}
-	fullMessage = fullMessage + Config.MattermostWebhookFooter
+	fullMessage = fullMessage + s.Config.MattermostWebhookFooter
 
 	webhookRequest := &WebhookRequest{Username: "Mattermod", Text: fullMessage}
 
-	if err := sendToWebhook(webhookRequest, Config.MattermostWebhookURL); err != nil {
+	if err := s.sendToWebhook(webhookRequest, s.Config.MattermostWebhookURL); err != nil {
 		mlog.Error("Unable to post to Mattermost webhook", mlog.Err(err))
 	}
 }

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -16,14 +16,14 @@ type WebhookRequest struct {
 	Text     string `json:"text"`
 }
 
-func sendToWebhook(webhookRequest *WebhookRequest, url string) error {
+func (s *Server) sendToWebhook(webhookRequest *WebhookRequest, url string) error {
 	b, err := json.Marshal(webhookRequest)
 	if err != nil {
 		return err
 	}
 
 	client := http.Client{}
-	request, err := http.NewRequest("POST", Config.MattermostWebhookURL, bytes.NewReader(b))
+	request, err := http.NewRequest("POST", s.Config.MattermostWebhookURL, bytes.NewReader(b))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The intention of this PR is to remove mattermod tech debt in order to 
provide a foundation for a better SpinWick experience. The primary
goal of this work was to begin addressing some of the race conditions
that exist when working with SpinWicks.

The following was included in these commits: 

- Enhanced Server struct and changed all related functions to
   methods of Server. The Server object is no longer a shared
   variable.
 - Moved the server config to belong to the server struct and not
   be a shared variable.
 - Provided a way to cleanly create, start, and stop a server.
 - Resolved issues with not returning errors when we should be.
- Refactors the spinwick code to no longer require the mattermod
   database.
 - Cleans up logic for creating, updating, and deleting SpinWicks
   to primarily occur as a direct result of github events.
 - Adds more tests where possible.

https://mattermost.atlassian.net/browse/MM-17073