### PR TITLE
remove label when test server fail and do some comments cleanup

### DIFF
--- a/server/github.go
+++ b/server/github.go
@@ -104,9 +104,29 @@ func (s *Server) commentOnIssue(repoOwner, repoName string, number int, comment 
 	client := NewGithubClient(s.Config.GithubAccessToken)
 	_, _, err := client.Issues.CreateComment(context.Background(), repoOwner, repoName, number, &github.IssueComment{Body: &comment})
 	if err != nil {
-		mlog.Error("Error", mlog.Err(err))
+		mlog.Error("Error commenting", mlog.Err(err))
 	}
 	mlog.Info("Finished commenting")
+}
+
+func (s *Server) removeLabel(repoOwner, repoName string, number int, label string) {
+	mlog.Info("Removing label on issue", mlog.Int("issue", number), mlog.String("label", label))
+	client := NewGithubClient(s.Config.GithubAccessToken)
+	_, err := client.Issues.RemoveLabelForIssue(context.Background(), repoOwner, repoName, number, label)
+	if err != nil {
+		mlog.Error("Error removing the label", mlog.Err(err))
+	}
+	mlog.Info("Finished removing the label")
+}
+
+func (s *Server) getComments(repoOwner, repoName string, number int) ([]*github.IssueComment, error) {
+	client := NewGithubClient(s.Config.GithubAccessToken)
+	comments, _, err := client.Issues.ListComments(context.Background(), repoOwner, repoName, number, nil)
+	if err != nil {
+		mlog.Error("pr_error", mlog.Err(err))
+		return nil, err
+	}
+	return comments, nil
 }
 
 func (s *Server) GetUpdateChecks(owner, repoName string, prNumber int) (*model.PullRequest, error) {

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -34,7 +34,7 @@ func (s *Server) handleCreateSpinWick(pr *model.PullRequest, size string) {
 			s.removeOldComments(comments, pr)
 		}
 		for _, label := range pr.Labels {
-			if label == s.Config.SetupSpinWick || label == s.Config.SetupSpinWickHA {
+			if s.isSpinWickLabel(label) {
 				s.removeLabel(pr.RepoOwner, pr.RepoName, pr.Number, label)
 			}
 		}

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -27,7 +27,6 @@ func (s *Server) handleCreateSpinWick(pr *model.PullRequest, size string) {
 	installationID, sendMattermostLog, err := s.createSpinWick(pr, size)
 	if err != nil {
 		mlog.Error("Failed to create SpinWick", mlog.Err(err), mlog.String("repo_name", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("installation_id", installationID))
-		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.SetupSpinmintFailedMessage)
 		comments, err := s.getComments(pr.RepoOwner, pr.RepoName, pr.Number)
 		if err != nil {
 			mlog.Error("Error getting comments", mlog.Err(err))
@@ -39,6 +38,7 @@ func (s *Server) handleCreateSpinWick(pr *model.PullRequest, size string) {
 				s.removeLabel(pr.RepoOwner, pr.RepoName, pr.Number, label)
 			}
 		}
+		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.SetupSpinmintFailedMessage)
 
 		if sendMattermostLog {
 			additionalFields := map[string]string{

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -28,6 +28,18 @@ func (s *Server) handleCreateSpinWick(pr *model.PullRequest, size string) {
 	if err != nil {
 		mlog.Error("Failed to create SpinWick", mlog.Err(err), mlog.String("repo_name", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("installation_id", installationID))
 		s.commentOnIssue(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.SetupSpinmintFailedMessage)
+		comments, err := s.getComments(pr.RepoOwner, pr.RepoName, pr.Number)
+		if err != nil {
+			mlog.Error("Error getting comments", mlog.Err(err))
+		} else {
+			s.removeOldComments(comments, pr)
+		}
+		for _, label := range pr.Labels {
+			if label == s.Config.SetupSpinWick || label == s.Config.SetupSpinWickHA {
+				s.removeLabel(pr.RepoOwner, pr.RepoName, pr.Number, label)
+			}
+		}
+
 		if sendMattermostLog {
 			additionalFields := map[string]string{
 				"Installation ID": installationID,


### PR DESCRIPTION
- when a spinwick fail remove the label and the comments when requesting for the first time
