### PR TITLE
Fix permission issues from PR/Forks triggering the circleci job with a org member

### DIFF
--- a/config/config-mattermod.json
+++ b/config/config-mattermod.json
@@ -4,6 +4,7 @@
     "GithubAccessToken": "",
     "GitHubTokenReserve": 50,
     "Username": "",
+    "CircleCIToken": "",
 
     "DriverName": "mysql",
     "DataSource": "",

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/aws/aws-sdk-go v1.23.2
 	github.com/braintree/manners v0.0.0-20160418043613-82a8879fc5fd
+	github.com/cpanato/go-circleci v0.3.1-0.20191007122438-7eb36e67d0f1
 	github.com/cpanato/golang-jenkins v0.0.0-20181010175751-6a66fc16d07d
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/go-gorp/gorp v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/corpix/uarand v0.1.0/go.mod h1:SFKZvkcRoLqVRFZ4u25xPmp6m9ktANfbpXZ7SJ0/FNU=
+github.com/cpanato/go-circleci v0.3.1-0.20191007122438-7eb36e67d0f1 h1:2el3ri7lrBnG971BWkIh6x69O46PtJUu9GcadcYcJjM=
+github.com/cpanato/go-circleci v0.3.1-0.20191007122438-7eb36e67d0f1/go.mod h1:hWXsPeLT+IR9aac18H4fB4bNx5gf3jAkF197p5Z5/5o=
 github.com/cpanato/golang-jenkins v0.0.0-20181010175751-6a66fc16d07d h1:lpvxq98+CdzxA1j7PntYAN7nNXjgypmuKAFv1gHewaw=
 github.com/cpanato/golang-jenkins v0.0.0-20181010175751-6a66fc16d07d/go.mod h1:vlKFkXzX7tHVygN5u1ZI7HLD0wlzfCeYaWnbOfFmvfQ=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=

--- a/model/pull_request.go
+++ b/model/pull_request.go
@@ -16,6 +16,7 @@ const (
 type PullRequest struct {
 	RepoOwner       string
 	RepoName        string
+	FullName        string
 	Number          int
 	Username        string
 	Ref             string

--- a/server/circleci.go
+++ b/server/circleci.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *Server) triggerCircleCiIfNeeded(pr *model.PullRequest) {
-	client := &circleci.Client{Token: s.Config.CircleCiToken}
+	client := &circleci.Client{Token: s.Config.CircleCIToken}
 
 	if strings.Contains(pr.FullName, "mattermost/") {
 		// It is from upstream mattermost repo dont need to trigger the circleci because org members

--- a/server/circleci.go
+++ b/server/circleci.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package server
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-mattermod/model"
+	"github.com/mattermost/mattermost-server/mlog"
+
+	"github.com/cpanato/go-circleci"
+)
+
+func (s *Server) triggerCircleCiIfNeeded(pr *model.PullRequest) {
+	client := &circleci.Client{Token: s.Config.CircleCiToken}
+
+	if strings.Contains(pr.FullName, "mattermost/") {
+		// It is from upstream mattermost repo dont need to trigger the circleci because org members
+		// have permissions
+		return
+	}
+
+	// Checking if the repo have circleci setup
+	builds, err := client.ListRecentBuildsForProject("mattermost", "mattermost-selenium", "master", "", 5, 0)
+	if err != nil {
+		mlog.Error("listing the circleci project", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName))
+		return
+	}
+	// if builds are 0 means no build ran for master and most problaby this is not setup, so skipping.
+	if len(builds) == 0 {
+		fmt.Println("looks like there is not circleci setup or master never ran. Skipping")
+		return
+	}
+
+	opts := map[string]interface{}{
+		"revision": pr.Sha,
+		"branch":   fmt.Sprintf("pull/%d", pr.Number),
+	}
+
+	err = client.BuildByProject("github", pr.RepoOwner, pr.RepoName, opts)
+	if err != nil {
+		mlog.Error("Error triggering circleci", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName))
+	}
+}

--- a/server/circleci.go
+++ b/server/circleci.go
@@ -23,7 +23,7 @@ func (s *Server) triggerCircleCiIfNeeded(pr *model.PullRequest) {
 	}
 
 	// Checking if the repo have circleci setup
-	builds, err := client.ListRecentBuildsForProject("mattermost", "mattermost-selenium", "master", "", 5, 0)
+	builds, err := client.ListRecentBuildsForProject(pr.RepoOwner, pr.RepoName, "master", "", 5, 0)
 	if err != nil {
 		mlog.Error("listing the circleci project", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName))
 		return

--- a/server/circleci.go
+++ b/server/circleci.go
@@ -16,7 +16,8 @@ import (
 func (s *Server) triggerCircleCiIfNeeded(pr *model.PullRequest) {
 	client := &circleci.Client{Token: s.Config.CircleCIToken}
 
-	if strings.Contains(pr.FullName, "mattermost/") {
+	repoInfo := strings.Split(pr.FullName, "/")
+	if repoInfo[0] == "mattermost" {
 		// It is from upstream mattermost repo dont need to trigger the circleci because org members
 		// have permissions
 		return

--- a/server/circleci.go
+++ b/server/circleci.go
@@ -30,7 +30,7 @@ func (s *Server) triggerCircleCiIfNeeded(pr *model.PullRequest) {
 	}
 	// if builds are 0 means no build ran for master and most problaby this is not setup, so skipping.
 	if len(builds) == 0 {
-		fmt.Println("looks like there is not circleci setup or master never ran. Skipping")
+		mlog.Debug("looks like there is not circleci setup or master never ran. Skipping")
 		return
 	}
 

--- a/server/config.go
+++ b/server/config.go
@@ -44,6 +44,7 @@ type ServerConfig struct {
 	Username                    string
 	AutoAssignerTeam            string
 	AutoAssignerTeamID          int64
+	CircleCiToken               string
 
 	TickRateMinutes        int
 	SpinmintExpirationHour int

--- a/server/config.go
+++ b/server/config.go
@@ -44,7 +44,7 @@ type ServerConfig struct {
 	Username                    string
 	AutoAssignerTeam            string
 	AutoAssignerTeamID          int64
-	CircleCiToken               string
+	CircleCIToken               string
 
 	TickRateMinutes        int
 	SpinmintExpirationHour int

--- a/server/github.go
+++ b/server/github.go
@@ -23,6 +23,7 @@ func (s *Server) GetPullRequestFromGithub(pullRequest *github.PullRequest) (*mod
 	pr := &model.PullRequest{
 		RepoOwner: *pullRequest.Base.Repo.Owner.Login,
 		RepoName:  *pullRequest.Base.Repo.Name,
+		FullName:  *pullRequest.Base.Repo.FullName,
 		Number:    *pullRequest.Number,
 		Username:  *pullRequest.User.Login,
 		Ref:       *pullRequest.Head.Ref,

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -26,9 +26,11 @@ func (s *Server) handlePullRequestEvent(event *PullRequestEvent) {
 	case "opened":
 		mlog.Info("PR opened", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number))
 		s.checkCLA(pr)
+		s.triggerCircleCiIfNeeded(pr)
 	case "reopened":
 		mlog.Info("PR reopened", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number))
 		s.checkCLA(pr)
+		s.triggerCircleCiIfNeeded(pr)
 	case "labeled":
 		if event.Label == nil {
 			mlog.Error("Label event received, but label object was empty")
@@ -63,6 +65,7 @@ func (s *Server) handlePullRequestEvent(event *PullRequestEvent) {
 	case "synchronize":
 		mlog.Info("PR has a new commit", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number))
 		s.checkCLA(pr)
+		s.triggerCircleCiIfNeeded(pr)
 		if s.isSpinWickLabelInLabels(pr.Labels) {
 			mlog.Info("PR has a SpinWick label, starting upgrade", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number))
 			if s.isSpinWickHALabel(pr.Labels) {

--- a/server/spinmint.go
+++ b/server/spinmint.go
@@ -86,7 +86,7 @@ import (
 // 	// Wait for the cluster restart after deploy
 // 	time.Sleep(time.Minute)
 
-// 	LogInfo("Runing loadtest for PR %v in %v/%v", pr.Number, pr.RepoOwner, pr.RepoName)
+// 	LogInfo("Running loadtest for PR %v in %v/%v", pr.Number, pr.RepoOwner, pr.RepoName)
 // 	if err := cluster.Loadtest(results); err != nil {
 // 		LogError("Unable to loadtest cluster: " + err.Error())
 // 		s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, "Failed to setup loadtest")

--- a/store/sql_pull_request_store.go
+++ b/store/sql_pull_request_store.go
@@ -22,6 +22,7 @@ func NewSqlPullRequestStore(sqlStore *SqlStore) PullRequestStore {
 		table.ColMap("RepoOwner").SetMaxSize(128)
 		table.ColMap("RepoName").SetMaxSize(128)
 		table.ColMap("Username").SetMaxSize(128)
+		table.ColMap("FullName").SetMaxSize(2083)
 		table.ColMap("Ref").SetMaxSize(128)
 		table.ColMap("Sha").SetMaxSize(48)
 		table.ColMap("State").SetMaxSize(8)
@@ -42,6 +43,7 @@ func (s SqlPullRequestStore) CreateIndexesIfNotExists() {
 	s.CreateColumnIfNotExists("PullRequests", "BuildStatus", "varchar(20)", "varchar(20)", "")
 	s.CreateColumnIfNotExists("PullRequests", "BuildConclusion", "varchar(20)", "varchar(20)", "")
 	s.CreateColumnIfNotExists("PullRequests", "URL", "varchar(20)", "varchar(2083)", "")
+	s.CreateColumnIfNotExists("PullRequests", "FullName", "varchar(2083)", "varchar(2083)", "")
 }
 
 func (s SqlPullRequestStore) Save(pr *model.PullRequest) StoreChannel {

--- a/vendor/github.com/cpanato/go-circleci/CHANGELOG.md
+++ b/vendor/github.com/cpanato/go-circleci/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Change Log
+
+**ATTN**: This project uses [semantic versioning](http://semver.org/).
+
+## [Unreleased]
+
+## 0.3.0 - 2019-06-29
+
+Added:
+
+* `Build`s now return `Workflow` information
+* `Build`s now return `Picard` information which describes the execution environment
+* `Build`s now return `Platform` information
+* `Action`s now return `Background` information
+* `CommitDetails` now return `Branch` and `PullRequest`
+* `BuildOpts` method for building a project with arbitrary parameters
+
+Bug fixes:
+
+* Fix issue with paginating queries returning a 401
+* Actually send build parameters for `ParameterizedBuild`
+* Fix feature flag parsing to not cause a null pointer panic
+
+## 0.2.0 - 2018-03-10
+
+Backwards incomptabile changes:
+
+* Switched `FeatureFlags` to a `struct` from `map[string]bool` as it was found that not all feature flags are `bool`s
+  (https://github.com/jszwedko/go-circleci/issues/8) which resulted in non-bool values being inaccessible. Known feature
+  flags are encoded as struct fields with a `.Raw()` method to access the underlying `map[string]interface{}` to access
+  unknown feature flags.
+
+## 0.1.0 - 2018-03-10
+
+### Added
+- Initial implementation.

--- a/vendor/github.com/cpanato/go-circleci/LICENSE
+++ b/vendor/github.com/cpanato/go-circleci/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Jesse Szwedko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/cpanato/go-circleci/README.md
+++ b/vendor/github.com/cpanato/go-circleci/README.md
@@ -1,0 +1,43 @@
+## go-circleci
+[![GoDoc](https://godoc.org/github.com/jszwedko/go-circleci?status.svg)](http://godoc.org/github.com/jszwedko/go-circleci)
+[![Circle CI](https://circleci.com/gh/jszwedko/go-circleci.svg?style=svg)](https://circleci.com/gh/jszwedko/go-circleci)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jszwedko/go-circleci)](https://goreportcard.com/report/github.com/jszwedko/go-circleci)
+[![coverage](https://gocover.io/_badge/github.com/jszwedko/go-circleci?0 "coverage")](http://gocover.io/github.com/jszwedko/go-circleci)
+
+Go library for interacting with [CircleCI's API](https://circleci.com/docs/api). Supports all current API endpoints allowing you do do things like:
+
+* Query for recent builds
+* Get build details
+* Retry builds
+* Manipulate checkout keys, environment variables, and other settings for a project
+
+**The CircleCI HTTP API response schemas are not well documented so please file an issue if you run into something that doesn't match up.**
+
+Example usage:
+
+```golang
+package main
+
+import (
+        "fmt"
+
+        "github.com/jszwedko/go-circleci"
+)
+
+func main() {
+        client := &circleci.Client{Token: "YOUR TOKEN"} // Token not required to query info for public projects
+
+        builds, _ := client.ListRecentBuildsForProject("jszwedko", "circleci-cli", "master", "", -1, 0)
+
+        for _, build := range builds {
+                fmt.Printf("%d: %s\n", build.BuildNum, build.Status)
+        }
+}
+```
+
+For the CLI that uses this library (or to see more example usages), please see
+[circleci-cli](https://github.com/jszwedko/circleci-cli).
+
+See [GoDoc](http://godoc.org/github.com/jszwedko/go-circleci) for API usage.
+
+Feature requests and issues welcome!

--- a/vendor/github.com/cpanato/go-circleci/circleci.go
+++ b/vendor/github.com/cpanato/go-circleci/circleci.go
@@ -1,0 +1,1092 @@
+package circleci
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	queryLimit = 100 // maximum that CircleCI allows
+)
+
+var (
+	defaultBaseURL = &url.URL{Host: "circleci.com", Scheme: "https", Path: "/api/v1/"}
+	defaultLogger  = log.New(os.Stderr, "", log.LstdFlags)
+)
+
+// Logger is a minimal interface for injecting custom logging logic for debug logs
+type Logger interface {
+	Printf(fmt string, args ...interface{})
+}
+
+// APIError represents an error from CircleCI
+type APIError struct {
+	HTTPStatusCode int
+	Message        string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("%d: %s", e.HTTPStatusCode, e.Message)
+}
+
+// Client is a CircleCI client
+// Its zero value is a usable client for examining public CircleCI repositories
+type Client struct {
+	BaseURL    *url.URL     // CircleCI API endpoint (defaults to DefaultEndpoint)
+	Token      string       // CircleCI API token (needed for private repositories and mutative actions)
+	HTTPClient *http.Client // HTTPClient to use for connecting to CircleCI (defaults to http.DefaultClient)
+
+	Debug  bool   // debug logging enabled
+	Logger Logger // logger to send debug messages on (if enabled), defaults to logging to stderr with the standard flags
+}
+
+func (c *Client) baseURL() *url.URL {
+	if c.BaseURL == nil {
+		return defaultBaseURL
+	}
+
+	return c.BaseURL
+}
+
+func (c *Client) client() *http.Client {
+	if c.HTTPClient == nil {
+		return http.DefaultClient
+	}
+
+	return c.HTTPClient
+}
+
+func (c *Client) logger() Logger {
+	if c.Logger == nil {
+		return defaultLogger
+	}
+
+	return c.Logger
+}
+
+func (c *Client) debug(format string, args ...interface{}) {
+	if c.Debug {
+		c.logger().Printf(format, args...)
+	}
+}
+
+func (c *Client) debugRequest(req *http.Request) {
+	if c.Debug {
+		out, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			c.debug("error debugging request %+v: %s", req, err)
+		}
+		c.debug("request:\n%+v", string(out))
+	}
+}
+
+func (c *Client) debugResponse(resp *http.Response) {
+	if c.Debug {
+		out, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			c.debug("error debugging response %+v: %s", resp, err)
+		}
+		c.debug("response:\n%+v", string(out))
+	}
+}
+
+type nopCloser struct {
+	io.Reader
+}
+
+func (n nopCloser) Close() error { return nil }
+
+func (c *Client) request(method, path string, responseStruct interface{}, params url.Values, bodyStruct interface{}) error {
+	if params == nil {
+		params = url.Values{}
+	}
+	params.Set("circle-token", c.Token)
+
+	u := c.baseURL().ResolveReference(&url.URL{Path: path, RawQuery: params.Encode()})
+
+	c.debug("building request for %s", u)
+
+	req, err := http.NewRequest(method, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	if bodyStruct != nil {
+		b, err := json.Marshal(bodyStruct)
+		if err != nil {
+			return err
+		}
+
+		req.Body = nopCloser{bytes.NewBuffer(b)}
+	}
+
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+
+	c.debugRequest(req)
+
+	resp, err := c.client().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	c.debugResponse(resp)
+
+	if resp.StatusCode >= 300 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return &APIError{HTTPStatusCode: resp.StatusCode, Message: "unable to parse response: %s"}
+		}
+
+		if len(body) > 0 {
+			message := struct {
+				Message string `json:"message"`
+			}{}
+			err = json.Unmarshal(body, &message)
+			if err != nil {
+				return &APIError{
+					HTTPStatusCode: resp.StatusCode,
+					Message:        fmt.Sprintf("unable to parse API response: %s", err),
+				}
+			}
+			return &APIError{HTTPStatusCode: resp.StatusCode, Message: message.Message}
+		}
+
+		return &APIError{HTTPStatusCode: resp.StatusCode}
+	}
+
+	if responseStruct != nil {
+		err = json.NewDecoder(resp.Body).Decode(responseStruct)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Me returns information about the current user
+func (c *Client) Me() (*User, error) {
+	user := &User{}
+
+	err := c.request("GET", "me", user, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}
+
+// ListProjects returns the list of projects the user is watching
+func (c *Client) ListProjects() ([]*Project, error) {
+	projects := []*Project{}
+
+	err := c.request("GET", "projects", &projects, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, project := range projects {
+		if err := cleanupProject(project); err != nil {
+			return nil, err
+		}
+	}
+
+	return projects, nil
+}
+
+// EnableProject enables a project - generates a deploy SSH key used to checkout the Github repo.
+// The Github user tied to the Circle API Token must have "admin" access to the repo.
+func (c *Client) EnableProject(account, repo string) error {
+	return c.request("POST", fmt.Sprintf("project/%s/%s/enable", account, repo), nil, nil, nil)
+}
+
+// DisableProject disables a project
+func (c *Client) DisableProject(account, repo string) error {
+	return c.request("DELETE", fmt.Sprintf("project/%s/%s/enable", account, repo), nil, nil, nil)
+}
+
+// FollowProject follows a project
+func (c *Client) FollowProject(account, repo string) (*Project, error) {
+	project := &Project{}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/follow", account, repo), project, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cleanupProject(project); err != nil {
+		return nil, err
+	}
+
+	return project, nil
+}
+
+// GetProject retrieves a specific project
+// Returns nil of the project is not in the list of watched projects
+func (c *Client) GetProject(account, repo string) (*Project, error) {
+	projects, err := c.ListProjects()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, project := range projects {
+		if account == project.Username && repo == project.Reponame {
+			return project, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (c *Client) recentBuilds(path string, params url.Values, limit, offset int) ([]*Build, error) {
+	allBuilds := []*Build{}
+
+	if params == nil {
+		params = url.Values{}
+	}
+
+	fetchAll := limit == -1
+	for {
+		builds := []*Build{}
+
+		if fetchAll {
+			limit = queryLimit + 1
+		}
+
+		l := limit
+		if l > queryLimit {
+			l = queryLimit
+		}
+
+		params.Set("limit", strconv.Itoa(l))
+		params.Set("offset", strconv.Itoa(offset))
+
+		err := c.request("GET", path, &builds, params, nil)
+		if err != nil {
+			return nil, err
+		}
+		allBuilds = append(allBuilds, builds...)
+
+		offset += len(builds)
+		limit -= len(builds)
+		if len(builds) < queryLimit || limit == 0 {
+			break
+		}
+	}
+
+	return allBuilds, nil
+}
+
+// ListRecentBuilds fetches the list of recent builds for all repositories the user is watching
+// If limit is -1, fetches all builds
+func (c *Client) ListRecentBuilds(limit, offset int) ([]*Build, error) {
+	return c.recentBuilds("recent-builds", nil, limit, offset)
+}
+
+// ListRecentBuildsForProject fetches the list of recent builds for the given repository
+// The status and branch parameters are used to further filter results if non-empty
+// If limit is -1, fetches all builds
+func (c *Client) ListRecentBuildsForProject(account, repo, branch, status string, limit, offset int) ([]*Build, error) {
+	path := fmt.Sprintf("project/%s/%s", account, repo)
+	if branch != "" {
+		path = fmt.Sprintf("%s/tree/%s", path, branch)
+	}
+
+	params := url.Values{}
+	if status != "" {
+		params.Set("filter", status)
+	}
+
+	return c.recentBuilds(path, params, limit, offset)
+}
+
+// GetBuild fetches a given build by number
+func (c *Client) GetBuild(account, repo string, buildNum int) (*Build, error) {
+	build := &Build{}
+
+	err := c.request("GET", fmt.Sprintf("project/%s/%s/%d", account, repo, buildNum), build, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return build, nil
+}
+
+// ListBuildArtifacts fetches the build artifacts for the given build
+func (c *Client) ListBuildArtifacts(account, repo string, buildNum int) ([]*Artifact, error) {
+	artifacts := []*Artifact{}
+
+	err := c.request("GET", fmt.Sprintf("project/%s/%s/%d/artifacts", account, repo, buildNum), &artifacts, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return artifacts, nil
+}
+
+// ListTestMetadata fetches the build metadata for the given build
+func (c *Client) ListTestMetadata(account, repo string, buildNum int) ([]*TestMetadata, error) {
+	metadata := struct {
+		Tests []*TestMetadata `json:"tests"`
+	}{}
+
+	err := c.request("GET", fmt.Sprintf("project/%s/%s/%d/tests", account, repo, buildNum), &metadata, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return metadata.Tests, nil
+}
+
+// AddSSHUser adds the user associated with the API token to the list of valid
+// SSH users for a build.
+//
+// The API token being used must be a user API token
+func (c *Client) AddSSHUser(account, repo string, buildNum int) (*Build, error) {
+	build := &Build{}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/%d/ssh-users", account, repo, buildNum), build, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return build, nil
+}
+
+// Build triggers a new build for the given project for the given
+// project on the given branch.
+// Returns the new build information
+func (c *Client) Build(account, repo, branch string) (*Build, error) {
+	return c.BuildOpts(account, repo, branch, nil)
+}
+
+// ParameterizedBuild triggers a new parameterized build for the given
+// project on the given branch, Marshaling the struct into json and passing
+// in the post body.
+// Returns the new build information
+func (c *Client) ParameterizedBuild(account, repo, branch string, buildParameters map[string]string) (*Build, error) {
+	opts := map[string]interface{}{"build_parameters": buildParameters}
+	return c.BuildOpts(account, repo, branch, opts)
+}
+
+// BuildOpts triggeres a new build for the givent project on the given
+// branch, Marshaling the struct into json and passing
+// in the post body.
+// Returns the new build information
+func (c *Client) BuildOpts(account, repo, branch string, opts map[string]interface{}) (*Build, error) {
+	build := &Build{}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return build, nil
+}
+
+// BuildByProjectBranch triggers a build by project (this is the only way to trigger a build for project using Circle
+// 2.1) by branch
+//
+// NOTE: this endpoint is only available in the CircleCI API v1.1. in order to call it, you must instantiate the Client
+// object with the following value for BaseURL: &url.URL{Host: "circleci.com", Scheme: "https", Path: "/api/v1.1/"}
+func (c *Client) BuildByProjectBranch(vcsType VcsType, account string, repo string, branch string) error {
+	return c.buildProject(vcsType, account, repo, map[string]interface{}{
+		"branch": branch,
+	})
+}
+
+// BuildByProjectRevision triggers a build by project (this is the only way to trigger a build for project using Circle
+// 2.1) by revision
+//
+// NOTE: this endpoint is only available in the CircleCI API v1.1. in order to call it, you must instantiate the Client
+// object with the following value for BaseURL: &url.URL{Host: "circleci.com", Scheme: "https", Path: "/api/v1.1/"}
+func (c *Client) BuildByProjectRevision(vcsType VcsType, account string, repo string, revision string) error {
+	return c.buildProject(vcsType, account, repo, map[string]interface{}{
+		"revision": revision,
+	})
+
+}
+
+// BuildByProjectTag triggers a build by project (this is the only way to trigger a build for project using Circle 2.1)
+// using a tag reference
+//
+// NOTE: this endpoint is only available in the CircleCI API v1.1. in order to call it, you must instantiate the Client
+// object with the following value for BaseURL: &url.URL{Host: "circleci.com", Scheme: "https", Path: "/api/v1.1/"}
+func (c *Client) BuildByProjectTag(vcsType VcsType, account string, repo string, tag string) error {
+	return c.buildProject(vcsType, account, repo, map[string]interface{}{
+		"tag": tag,
+	})
+}
+
+// BuildByProject triggers a build by project (this is the only way to trigger a build for project using Circle 2.1)
+// you can set revision and/or tag/branch
+// this is useful if you need to trigger a build from a PR froma fork, in which you need to set the revision and the
+// branch in this format `pull/PR_NUMBER`
+// ie.:
+//  map[string]interface{}{
+// 		"revision": "8afbae7ec63b2b0f2786740d03161dbb08ba55f5",
+//		"branch"  : "pull/1234",
+// 	})
+//
+// NOTE: this endpoint is only available in the CircleCI API v1.1. in order to call it, you must instantiate the Client
+// object with the following value for BaseURL: &url.URL{Host: "circleci.com", Scheme: "https", Path: "/api/v1.1/"}
+func (c *Client) BuildByProject(vcsType VcsType, account string, repo string, opts map[string]interface{}) error {
+	return c.buildProject(vcsType, account, repo, opts)
+}
+
+func (c *Client) buildProject(vcsType VcsType, account string, repo string, opts map[string]interface{}) error {
+	resp := &BuildByProjectResponse{}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/%s/build", vcsType, account, repo), resp, nil, opts)
+	if err != nil {
+		return err
+	}
+
+	if resp.Status != 200 || resp.Body != "Build created" {
+		return fmt.Errorf("unexpected build info in response %+v", resp)
+	}
+	return nil
+}
+
+// RetryBuild triggers a retry of the specified build
+// Returns the new build information
+func (c *Client) RetryBuild(account, repo string, buildNum int) (*Build, error) {
+	build := &Build{}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/%d/retry", account, repo, buildNum), build, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return build, nil
+}
+
+// CancelBuild triggers a cancel of the specified build
+// Returns the new build information
+func (c *Client) CancelBuild(account, repo string, buildNum int) (*Build, error) {
+	build := &Build{}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/%d/cancel", account, repo, buildNum), build, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return build, nil
+}
+
+// ClearCache clears the cache of the specified project
+// Returns the status returned by CircleCI
+func (c *Client) ClearCache(account, repo string) (string, error) {
+	status := &struct {
+		Status string `json:"status"`
+	}{}
+
+	err := c.request("DELETE", fmt.Sprintf("project/%s/%s/build-cache", account, repo), status, nil, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return status.Status, nil
+}
+
+// AddEnvVar adds a new environment variable to the specified project
+// Returns the added env var (the value will be masked)
+func (c *Client) AddEnvVar(account, repo, name, value string) (*EnvVar, error) {
+	envVar := &EnvVar{}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/envvar", account, repo), envVar, nil, &EnvVar{Name: name, Value: value})
+	if err != nil {
+		return nil, err
+	}
+
+	return envVar, nil
+}
+
+// ListEnvVars list environment variable to the specified project
+// Returns the env vars (the value will be masked)
+func (c *Client) ListEnvVars(account, repo string) ([]EnvVar, error) {
+	envVar := []EnvVar{}
+
+	err := c.request("GET", fmt.Sprintf("project/%s/%s/envvar", account, repo), &envVar, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return envVar, nil
+}
+
+// DeleteEnvVar deletes the specified environment variable from the project
+func (c *Client) DeleteEnvVar(account, repo, name string) error {
+	return c.request("DELETE", fmt.Sprintf("project/%s/%s/envvar/%s", account, repo, name), nil, nil, nil)
+}
+
+// AddSSHKey adds a new SSH key to the project
+func (c *Client) AddSSHKey(account, repo, hostname, privateKey string) error {
+	key := &struct {
+		Hostname   string `json:"hostname"`
+		PrivateKey string `json:"private_key"`
+	}{hostname, privateKey}
+	return c.request("POST", fmt.Sprintf("project/%s/%s/ssh-key", account, repo), nil, nil, key)
+}
+
+// GetActionOutputs fetches the output for the given action
+// If the action has no output, returns nil
+func (c *Client) GetActionOutputs(a *Action) ([]*Output, error) {
+	if !a.HasOutput || a.OutputURL == "" {
+		return nil, nil
+	}
+
+	req, err := http.NewRequest("GET", a.OutputURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	c.debugRequest(req)
+
+	resp, err := c.client().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	c.debugResponse(resp)
+
+	output := []*Output{}
+	if err = json.NewDecoder(resp.Body).Decode(&output); err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+// ListCheckoutKeys fetches the checkout keys associated with the given project
+func (c *Client) ListCheckoutKeys(account, repo string) ([]*CheckoutKey, error) {
+	checkoutKeys := []*CheckoutKey{}
+
+	err := c.request("GET", fmt.Sprintf("project/%s/%s/checkout-key", account, repo), &checkoutKeys, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return checkoutKeys, nil
+}
+
+// CreateCheckoutKey creates a new checkout key for a project
+// Valid key types are currently deploy-key and github-user-key
+//
+// The github-user-key type requires that the API token being used be a user API token
+func (c *Client) CreateCheckoutKey(account, repo, keyType string) (*CheckoutKey, error) {
+	checkoutKey := &CheckoutKey{}
+
+	body := struct {
+		KeyType string `json:"type"`
+	}{KeyType: keyType}
+
+	err := c.request("POST", fmt.Sprintf("project/%s/%s/checkout-key", account, repo), checkoutKey, nil, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return checkoutKey, nil
+}
+
+// GetCheckoutKey fetches the checkout key for the given project by fingerprint
+func (c *Client) GetCheckoutKey(account, repo, fingerprint string) (*CheckoutKey, error) {
+	checkoutKey := &CheckoutKey{}
+
+	err := c.request("GET", fmt.Sprintf("project/%s/%s/checkout-key/%s", account, repo, fingerprint), &checkoutKey, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return checkoutKey, nil
+}
+
+// DeleteCheckoutKey fetches the checkout key for the given project by fingerprint
+func (c *Client) DeleteCheckoutKey(account, repo, fingerprint string) error {
+	return c.request("DELETE", fmt.Sprintf("project/%s/%s/checkout-key/%s", account, repo, fingerprint), nil, nil, nil)
+}
+
+// AddHerokuKey associates a Heroku key with the user's API token to allow
+// CircleCI to deploy to Heroku on your behalf
+//
+// The API token being used must be a user API token
+//
+// NOTE: It doesn't look like there is currently a way to dissaccociate your
+// Heroku key, so use with care
+func (c *Client) AddHerokuKey(key string) error {
+	body := struct {
+		APIKey string `json:"apikey"`
+	}{APIKey: key}
+
+	return c.request("POST", "/user/heroku-key", nil, nil, body)
+}
+
+// EnvVar represents an environment variable
+type EnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// Artifact represents a build artifact
+type Artifact struct {
+	NodeIndex  int    `json:"node_index"`
+	Path       string `json:"path"`
+	PrettyPath string `json:"pretty_path"`
+	URL        string `json:"url"`
+}
+
+// UserProject returns the selective project information included when querying
+// for a User
+type UserProject struct {
+	Emails      string `json:"emails"`
+	OnDashboard bool   `json:"on_dashboard"`
+}
+
+// User represents a CircleCI user
+type User struct {
+	Admin               bool                    `json:"admin"`
+	AllEmails           []string                `json:"all_emails"`
+	AvatarURL           string                  `json:"avatar_url"`
+	BasicEmailPrefs     string                  `json:"basic_email_prefs"`
+	Containers          int                     `json:"containers"`
+	CreatedAt           time.Time               `json:"created_at"`
+	DaysLeftInTrial     int                     `json:"days_left_in_trial"`
+	GithubID            int                     `json:"github_id"`
+	GithubOauthScopes   []string                `json:"github_oauth_scopes"`
+	GravatarID          *string                 `json:"gravatar_id"`
+	HerokuAPIKey        *string                 `json:"heroku_api_key"`
+	LastViewedChangelog time.Time               `json:"last_viewed_changelog"`
+	Login               string                  `json:"login"`
+	Name                *string                 `json:"name"`
+	Parallelism         int                     `json:"parallelism"`
+	Plan                *string                 `json:"plan"`
+	Projects            map[string]*UserProject `json:"projects"`
+	SelectedEmail       *string                 `json:"selected_email"`
+	SignInCount         int                     `json:"sign_in_count"`
+	TrialEnd            time.Time               `json:"trial_end"`
+}
+
+// AWSConfig represents AWS configuration for a project
+type AWSConfig struct {
+	AWSKeypair *AWSKeypair `json:"keypair"`
+}
+
+// AWSKeypair represents the AWS access/secret key for a project
+// SecretAccessKey will be a masked value
+type AWSKeypair struct {
+	AccessKeyID     string `json:"access_key_id"`
+	SecretAccessKey string `json:"secret_access_key_id"`
+}
+
+// BuildSummary represents the subset of build information returned with a Project
+type BuildSummary struct {
+	AddedAt     time.Time `json:"added_at"`
+	BuildNum    int       `json:"build_num"`
+	Outcome     string    `json:"outcome"`
+	PushedAt    time.Time `json:"pushed_at"`
+	Status      string    `json:"status"`
+	VCSRevision string    `json:"vcs_revision"`
+}
+
+// Branch represents a repository branch
+type Branch struct {
+	LastSuccess   *BuildSummary   `json:"last_success"`
+	PusherLogins  []string        `json:"pusher_logins"`
+	RecentBuilds  []*BuildSummary `json:"recent_builds"`
+	RunningBuilds []*BuildSummary `json:"running_builds"`
+}
+
+// PublicSSHKey represents the public part of an SSH key associated with a project
+// PrivateKey will be a masked value
+type PublicSSHKey struct {
+	Hostname    string `json:"hostname"`
+	PublicKey   string `json:"public_key"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+// Project represents information about a project
+type Project struct {
+	AWSConfig           AWSConfig         `json:"aws"`
+	Branches            map[string]Branch `json:"branches"`
+	CampfireNotifyPrefs *string           `json:"campfire_notify_prefs"`
+	CampfireRoom        *string           `json:"campfire_room"`
+	CampfireSubdomain   *string           `json:"campfire_subdomain"`
+	CampfireToken       *string           `json:"campfire_token"`
+	Compile             string            `json:"compile"`
+	DefaultBranch       string            `json:"default_branch"`
+	Dependencies        string            `json:"dependencies"`
+	Extra               string            `json:"extra"`
+	FeatureFlags        FeatureFlags      `json:"feature_flags"`
+	FlowdockAPIToken    *string           `json:"flowdock_api_token"`
+	Followed            bool              `json:"followed"`
+	HallNotifyPrefs     *string           `json:"hall_notify_prefs"`
+	HallRoomAPIToken    *string           `json:"hall_room_api_token"`
+	HasUsableKey        bool              `json:"has_usable_key"`
+	HerokuDeployUser    *string           `json:"heroku_deploy_user"`
+	HipchatAPIToken     *string           `json:"hipchat_api_token"`
+	HipchatNotify       *bool             `json:"hipchat_notify"`
+	HipchatNotifyPrefs  *string           `json:"hipchat_notify_prefs"`
+	HipchatRoom         *string           `json:"hipchat_room"`
+	IrcChannel          *string           `json:"irc_channel"`
+	IrcKeyword          *string           `json:"irc_keyword"`
+	IrcNotifyPrefs      *string           `json:"irc_notify_prefs"`
+	IrcPassword         *string           `json:"irc_password"`
+	IrcServer           *string           `json:"irc_server"`
+	IrcUsername         *string           `json:"irc_username"`
+	Parallel            int               `json:"parallel"`
+	Reponame            string            `json:"reponame"`
+	Setup               string            `json:"setup"`
+	SlackAPIToken       *string           `json:"slack_api_token"`
+	SlackChannel        *string           `json:"slack_channel"`
+	SlackNotifyPrefs    *string           `json:"slack_notify_prefs"`
+	SlackSubdomain      *string           `json:"slack_subdomain"`
+	SlackWebhookURL     *string           `json:"slack_webhook_url"`
+	SSHKeys             []*PublicSSHKey   `json:"ssh_keys"`
+	Test                string            `json:"test"`
+	Username            string            `json:"username"`
+	VCSURL              string            `json:"vcs_url"`
+}
+
+type FeatureFlags struct {
+	TrustyBeta             bool    `json:"trusty-beta"`
+	OSX                    bool    `json:"osx"`
+	SetGithubStatus        bool    `json:"set-github-status"`
+	BuildPRsOnly           bool    `json:"build-prs-only"`
+	ForksReceiveSecretVars bool    `json:"forks-receive-secret-env-vars"`
+	Fleet                  *string `json:"fleet"`
+	BuildForkPRs           bool    `json:"build-fork-prs"`
+	AutocancelBuilds       bool    `json:"autocancel-builds"`
+	OSS                    bool    `json:"oss"`
+	MemoryLimit            *string `json:"memory-limit"`
+
+	raw map[string]interface{}
+}
+
+func (f *FeatureFlags) UnmarshalJSON(b []byte) error {
+	if err := json.Unmarshal(b, &f.raw); err != nil {
+		return err
+	}
+
+	if v, ok := f.raw["trusty-beta"]; ok {
+		f.TrustyBeta = v.(bool)
+	}
+
+	if v, ok := f.raw["osx"]; ok {
+		f.OSX = v.(bool)
+	}
+
+	if v, ok := f.raw["set-github-status"]; ok {
+		f.SetGithubStatus = v.(bool)
+	}
+
+	if v, ok := f.raw["build-prs-only"]; ok {
+		f.BuildPRsOnly = v.(bool)
+	}
+
+	if v, ok := f.raw["forks-receive-secret-env-vars"]; ok {
+		f.ForksReceiveSecretVars = v.(bool)
+	}
+
+	if v, ok := f.raw["fleet"]; ok {
+		if v != nil {
+			s := v.(string)
+			f.Fleet = &s
+		}
+	}
+
+	if v, ok := f.raw["build-fork-prs"]; ok {
+		f.BuildForkPRs = v.(bool)
+	}
+
+	if v, ok := f.raw["autocancel-builds"]; ok {
+		f.AutocancelBuilds = v.(bool)
+	}
+
+	if v, ok := f.raw["oss"]; ok {
+		f.OSS = v.(bool)
+	}
+
+	if v, ok := f.raw["memory-limit"]; ok {
+		if v != nil {
+			s := v.(string)
+			f.MemoryLimit = &s
+		}
+	}
+
+	return nil
+}
+
+// Raw returns the underlying map[string]interface{} representing the feature flags
+// This is useful to access flags that have been added to the API, but not yet added to this library
+func (f *FeatureFlags) Raw() map[string]interface{} {
+	return f.raw
+}
+
+// CommitDetails represents information about a commit returned with other
+// structs
+type CommitDetails struct {
+	AuthorDate     *time.Time `json:"author_date"`
+	AuthorEmail    string     `json:"author_email"`
+	AuthorLogin    string     `json:"author_login"`
+	AuthorName     string     `json:"author_name"`
+	Body           string     `json:"body"`
+	Branch         string     `json:"branch"`
+	Commit         string     `json:"commit"`
+	CommitURL      string     `json:"commit_url"`
+	CommitterDate  *time.Time `json:"committer_date"`
+	CommitterEmail string     `json:"committer_email"`
+	CommitterLogin string     `json:"committer_login"`
+	CommitterName  string     `json:"committer_name"`
+	Subject        string     `json:"subject"`
+}
+
+// Message represents build messages
+type Message struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+// Node represents the node a build was run on
+type Node struct {
+	ImageID      string `json:"image_id"`
+	Port         int    `json:"port"`
+	PublicIPAddr string `json:"public_ip_addr"`
+	SSHEnabled   *bool  `json:"ssh_enabled"`
+	Username     string `json:"username"`
+}
+
+// CircleYML represents the serialized CircleCI YML file for a given build
+type CircleYML struct {
+	String string `json:"string"`
+}
+
+// BuildStatus represents status information about the build
+// Used when a short summary of previous builds is included
+type BuildStatus struct {
+	BuildTimeMillis int    `json:"build_time_millis"`
+	Status          string `json:"status"`
+	BuildNum        int    `json:"build_num"`
+}
+
+// BuildUser represents the user that triggered the build
+type BuildUser struct {
+	Email  *string `json:"email"`
+	IsUser bool    `json:"is_user"`
+	Login  string  `json:"login"`
+	Name   *string `json:"name"`
+}
+
+// Workflow represents the details of the workflow for a build
+type Workflow struct {
+	JobName        string    `json:"job_name"`
+	JobId          string    `json:"job_id"`
+	UpstreamJobIds []*string `json:"upstream_job_ids"`
+	WorkflowId     string    `json:"workflow_id"`
+	WorkspaceId    string    `json:"workspace_id"`
+	WorkflowName   string    `json:"workflow_name"`
+}
+
+// Build represents the details of a build
+type Build struct {
+	AllCommitDetails        []*CommitDetails  `json:"all_commit_details"`
+	AuthorDate              *time.Time        `json:"author_date"`
+	AuthorEmail             string            `json:"author_email"`
+	AuthorName              string            `json:"author_name"`
+	Body                    string            `json:"body"`
+	Branch                  string            `json:"branch"`
+	BuildNum                int               `json:"build_num"`
+	BuildParameters         map[string]string `json:"build_parameters"`
+	BuildTimeMillis         *int              `json:"build_time_millis"`
+	BuildURL                string            `json:"build_url"`
+	Canceled                bool              `json:"canceled"`
+	CircleYML               *CircleYML        `json:"circle_yml"`
+	CommitterDate           *time.Time        `json:"committer_date"`
+	CommitterEmail          string            `json:"committer_email"`
+	CommitterName           string            `json:"committer_name"`
+	Compare                 *string           `json:"compare"`
+	DontBuild               *string           `json:"dont_build"`
+	Failed                  *bool             `json:"failed"`
+	FeatureFlags            map[string]string `json:"feature_flags"`
+	InfrastructureFail      bool              `json:"infrastructure_fail"`
+	IsFirstGreenBuild       bool              `json:"is_first_green_build"`
+	JobName                 *string           `json:"job_name"`
+	Lifecycle               string            `json:"lifecycle"`
+	Messages                []*Message        `json:"messages"`
+	Node                    []*Node           `json:"node"`
+	OSS                     bool              `json:"oss"`
+	Outcome                 string            `json:"outcome"`
+	Parallel                int               `json:"parallel"`
+	Picard                  *Picard           `json:"picard"`
+	Platform                string            `json:"platform"`
+	Previous                *BuildStatus      `json:"previous"`
+	PreviousSuccessfulBuild *BuildStatus      `json:"previous_successful_build"`
+	PullRequests            []*PullRequest    `json:"pull_requests"`
+	QueuedAt                string            `json:"queued_at"`
+	Reponame                string            `json:"reponame"`
+	Retries                 []int             `json:"retries"`
+	RetryOf                 *int              `json:"retry_of"`
+	SSHEnabled              *bool             `json:"ssh_enabled"`
+	SSHUsers                []*SSHUser        `json:"ssh_users"`
+	StartTime               *time.Time        `json:"start_time"`
+	Status                  string            `json:"status"`
+	Steps                   []*Step           `json:"steps"`
+	StopTime                *time.Time        `json:"stop_time"`
+	Subject                 string            `json:"subject"`
+	Timedout                bool              `json:"timedout"`
+	UsageQueuedAt           string            `json:"usage_queued_at"`
+	User                    *BuildUser        `json:"user"`
+	Username                string            `json:"username"`
+	VcsRevision             string            `json:"vcs_revision"`
+	VcsTag                  string            `json:"vcs_tag"`
+	VCSURL                  string            `json:"vcs_url"`
+	Workflows               *Workflow         `json:"workflows"`
+	Why                     string            `json:"why"`
+}
+
+// Picard represents metadata about an execution environment
+type Picard struct {
+	BuildAgent    *BuildAgent    `json:"build_agent"`
+	ResourceClass *ResourceClass `json:"resource_class"`
+	Executor      string         `json:"executor"`
+}
+
+// PullRequest represents a pull request
+type PullRequest struct {
+	HeadSha string `json:"head_sha"`
+	URL     string `json:"url"`
+}
+
+// ResourceClass represents usable resource information for a job
+type ResourceClass struct {
+	CPU   float64 `json:"cpu"`
+	RAM   int     `json:"ram"`
+	Class string  `json:"class"`
+}
+
+// BuildAgent represents an agent's information
+type BuildAgent struct {
+	Image      *string               `json:"image"`
+	Properties *BuildAgentProperties `json:"properties"`
+}
+
+// BuildAgentProperties represents agent properties
+type BuildAgentProperties struct {
+	BuildAgent string `json:"image"`
+	Executor   string `json:"executor"`
+}
+
+// Step represents an individual step in a build
+// Will contain more than one action if the step was parallelized
+type Step struct {
+	Name    string    `json:"name"`
+	Actions []*Action `json:"actions"`
+}
+
+// Action represents an individual action within a build step
+type Action struct {
+	Background         bool       `json:"background"`
+	BashCommand        *string    `json:"bash_command"`
+	Canceled           *bool      `json:"canceled"`
+	Continue           *string    `json:"continue"`
+	EndTime            *time.Time `json:"end_time"`
+	ExitCode           *int       `json:"exit_code"`
+	Failed             *bool      `json:"failed"`
+	HasOutput          bool       `json:"has_output"`
+	Index              int        `json:"index"`
+	InfrastructureFail *bool      `json:"infrastructure_fail"`
+	Messages           []string   `json:"messages"`
+	Name               string     `json:"name"`
+	OutputURL          string     `json:"output_url"`
+	Parallel           bool       `json:"parallel"`
+	RunTimeMillis      int        `json:"run_time_millis"`
+	StartTime          *time.Time `json:"start_time"`
+	Status             string     `json:"status"`
+	Step               int        `json:"step"`
+	Timedout           *bool      `json:"timedout"`
+	Truncated          bool       `json:"truncated"`
+	Type               string     `json:"type"`
+}
+
+// TestMetadata represents metadata collected from the test run (e.g. JUnit output)
+type TestMetadata struct {
+	Classname  string  `json:"classname"`
+	File       string  `json:"file"`
+	Message    *string `json:"message"`
+	Name       string  `json:"name"`
+	Result     string  `json:"result"`
+	RunTime    float64 `json:"run_time"`
+	Source     string  `json:"source"`
+	SourceType string  `json:"source_type"`
+}
+
+// Output represents the output of a given action
+type Output struct {
+	Type    string    `json:"type"`
+	Time    time.Time `json:"time"`
+	Message string    `json:"message"`
+}
+
+// SSHUser represents a user associated with an build with SSH enabled
+type SSHUser struct {
+	GithubID int    `json:"github_id"`
+	Login    string `json:"login"`
+}
+
+// CheckoutKey represents an SSH checkout key for a project
+type CheckoutKey struct {
+	PublicKey   string    `json:"public_key"`
+	Type        string    `json:"type"` // github-user-key or deploy-key
+	Fingerprint string    `json:"fingerprint"`
+	Login       *string   `json:"login"` // github username if this is a user key
+	Preferred   bool      `json:"preferred"`
+	Time        time.Time `json:"time"` // time key was created
+}
+
+// VcsType represents the version control system type
+type VcsType string
+
+// VcsType constants (github and bitbucket are the currently supported choices)
+const (
+	VcsTypeGithub    VcsType = "github"
+	VcsTypeBitbucket VcsType = "bitbucket"
+)
+
+// BuildByProjectResponse is the shape of the response body from the trigger build by project endpoint
+type BuildByProjectResponse struct {
+	Status int    `json:"status"`
+	Body   string `json:"body"`
+}
+
+// clean up project returned from API by:
+// * url decoding branch names (https://discuss.circleci.com/t/api-returns-url-encoded-branch-names-in-json-response/18524/5)
+func cleanupProject(project *Project) error {
+	if project.Branches == nil {
+		return nil
+	}
+
+	newBranches := map[string]Branch{}
+	for name, branch := range project.Branches {
+		escapedName, err := url.QueryUnescape(name)
+		if err != nil {
+			return fmt.Errorf("error url decoding branch name '%s':  %s", name, err)
+		}
+
+		newBranches[escapedName] = branch
+	}
+	project.Branches = newBranches
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -38,6 +38,8 @@ github.com/aws/aws-sdk-go/private/protocol/json/jsonutil
 github.com/blang/semver
 # github.com/braintree/manners v0.0.0-20160418043613-82a8879fc5fd
 github.com/braintree/manners
+# github.com/cpanato/go-circleci v0.3.1-0.20191007122438-7eb36e67d0f1
+github.com/cpanato/go-circleci
 # github.com/cpanato/golang-jenkins v0.0.0-20181010175751-6a66fc16d07d
 github.com/cpanato/golang-jenkins
 # github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
Context:
we have circleci for our CI pipelines for almost all public repos we have.
In circleci we use the feature called `context` which inject environment variables in the build, this env var contains some secrets to upload data to s3 or push docker images. This does not work when the build is running from a Fork/PR.
This PR fixes this issue we have that every time someone from the org needs to retrigger the job if that comes from a PR/Fork
this retriggers the job and the previous one will be canceled.


next: add a slash command to retrigger the build if that fail