### PR TITLE
Automatically add Hacktoberfest label to new community PRs

### DIFF
--- a/model/pull_request.go
+++ b/model/pull_request.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"time"
 )
 
 const (
@@ -27,6 +28,7 @@ type PullRequest struct {
 	BuildConclusion string
 	BuildLink       string
 	URL             string
+	CreatedAt       time.Time
 }
 
 func (o *PullRequest) ToJson() (string, error) {

--- a/server/community.go
+++ b/server/community.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/mattermost/mattermost-mattermod/model"
+	"github.com/mattermost/mattermost-server/mlog"
+)
+
+func (s *Server) addHacktoberfestLabel(pr *model.PullRequest) {
+	if pr.State == "closed" {
+		return
+	}
+
+	// Ignore PRs not created in october
+	if pr.CreatedAt.Month() != time.October {
+		return
+	}
+
+	isContributorOrgMember, err := s.isOrgMember("mattermost", pr.Username)
+	if err != nil {
+		mlog.Error("Error getting org membership", mlog.Err(err), mlog.Int("PR", pr.Number), mlog.String("Repo", pr.RepoName))
+		return
+	}
+	// Don't apply label if the contributors is a core committer
+	if isContributorOrgMember {
+		return
+	}
+
+	client := NewGithubClient(s.Config.GithubAccessToken)
+	_, _, err = client.Issues.AddLabelsToIssue(context.Background(), pr.RepoOwner, pr.RepoName, pr.Number, []string{"Hacktoberfest"})
+	if err != nil {
+		mlog.Error("Error applying Hacktoberfest label", mlog.Err(err), mlog.Int("PR", pr.Number), mlog.String("Repo", pr.RepoName))
+		return
+	}
+}

--- a/server/github.go
+++ b/server/github.go
@@ -30,6 +30,7 @@ func (s *Server) GetPullRequestFromGithub(pullRequest *github.PullRequest) (*mod
 		Sha:       *pullRequest.Head.SHA,
 		State:     *pullRequest.State,
 		URL:       *pullRequest.URL,
+		CreatedAt: pullRequest.GetCreatedAt(),
 	}
 
 	if pullRequest.Head.Repo != nil {

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -27,6 +27,7 @@ func (s *Server) handlePullRequestEvent(event *PullRequestEvent) {
 		mlog.Info("PR opened", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number))
 		s.checkCLA(pr)
 		s.triggerCircleCiIfNeeded(pr)
+		s.addHacktoberfestLabel(pr)
 	case "reopened":
 		mlog.Info("PR reopened", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number))
 		s.checkCLA(pr)


### PR DESCRIPTION
When a new PR in October is created and the contributor is not a GitHub org member, Mattermod now adds the `Hacktoberfest` label. This should make sure, we don't forget it.

cc @amyblais @jasonblais 