### PR TITLE
add update branch command

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -214,6 +214,9 @@ func (s *Server) githubEvent(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(strings.TrimSpace(*eventIssueComment.Comment.Body), "/autoassign") {
 			s.handleAutoassign(*eventIssueComment)
 		}
+		if strings.Contains(strings.TrimSpace(*eventIssueComment.Comment.Body), "/update-branch") {
+			s.handleUpdateBranch(*eventIssueComment)
+		}
 		return
 	}
 

--- a/server/update_branch.go
+++ b/server/update_branch.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/mattermost/mattermost-server/mlog"
+
+	"github.com/google/go-github/v28/github"
+)
+
+func (s *Server) handleUpdateBranch(eventIssueComment IssueComment) {
+	client := NewGithubClient(s.Config.GithubAccessToken)
+	prGitHub, _, err := client.PullRequests.Get(context.Background(), *eventIssueComment.Repository.Owner.Login, *eventIssueComment.Repository.Name, *eventIssueComment.Issue.Number)
+	if err != nil {
+		mlog.Error("Error getting the latest PR information from github", mlog.Err(err))
+		return
+	}
+	pr, err := s.GetPullRequestFromGithub(prGitHub)
+	if err != nil {
+		mlog.Error("Error Updating the PR in the DB", mlog.Err(err))
+		return
+	}
+
+	userComment := *eventIssueComment.Comment.User
+	if !s.checkUserPermission(userComment.GetLogin(), pr.RepoOwner) {
+		s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, "Looks like you dont have permissions to trigger this command.\n Only available for Org members")
+		return
+	}
+
+	opt := &github.PullReqestBranchUpdateOptions{
+		ExpectedHeadSHA: github.String(pr.Sha),
+	}
+
+	_, resp, err := client.PullRequests.UpdateBranch(context.Background(), pr.RepoOwner, pr.RepoName, pr.Number, opt)
+	if resp.StatusCode != http.StatusAccepted {
+		s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, "Error trying to update the PR.\nPlease do it manually.")
+		return
+	}
+	if err != nil {
+		if !strings.Contains("job scheduled on GitHub side; try again later", err.Error()) {
+			msg := fmt.Sprintf("Error trying to update the PR.\nPlease do it manually.\nError: %s", err.Error())
+			s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
+		}
+	}
+}

--- a/server/update_branch.go
+++ b/server/update_branch.go
@@ -30,6 +30,11 @@ func (s *Server) handleUpdateBranch(eventIssueComment IssueComment) {
 		return
 	}
 
+	if !prGitHub.GetMaintainerCanModify() {
+		s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, "We dont have permissions to update this PR, please contact the submitter to apply the update.")
+		return
+	}
+
 	opt := &github.PullReqestBranchUpdateOptions{
 		ExpectedHeadSHA: github.String(pr.Sha),
 	}


### PR DESCRIPTION
This adds the ability to update the PR with the latest upstream.
this is handy when the Core Members need to merge a PR and that needs an update.

the command is `/update-branch` and will try to update the branch if it fails will post a message and you will need to do manually 