### PR TITLE
fix the file check, getting the list of files for a PR

### DIFF
--- a/server/circleci.go
+++ b/server/circleci.go
@@ -39,26 +39,20 @@ func (s *Server) triggerCircleCiIfNeeded(pr *model.PullRequest) {
 		return
 	}
 
-	prCommits, _, err := clientGitHub.PullRequests.ListCommits(context.Background(), pr.RepoOwner, pr.RepoName, pr.Number, nil)
+	// List th files that was modified or added in the PullRequest
+	prFiles, _, err := clientGitHub.PullRequests.ListFiles(context.Background(), pr.RepoOwner, pr.RepoName, pr.Number, nil)
 	if err != nil {
-		mlog.Error("Error listing the commits from a PR", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName), mlog.Err(err))
+		mlog.Error("Error listing the files from a PR", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName), mlog.Err(err))
 		return
 	}
 
-	for _, commit := range prCommits {
-		prCommit, _, errCommit := clientGitHub.Repositories.GetCommit(context.Background(), pr.RepoOwner, pr.RepoName, commit.GetSHA())
-		if errCommit != nil {
-			mlog.Error("Error getting the commits from a PR", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName), mlog.Err(errCommit))
-			return
-		}
-		for _, file := range prCommit.Files {
-			for _, blackListPath := range s.Config.BlacklistPaths {
-				if file.GetFilename() == blackListPath {
-					mlog.Error("File is on the blacklist and will not retrigger circleci to give the contexts", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName))
-					msg := fmt.Sprintf("The file `%s` is in the blacklist and should not be modified from external contributors, please if you are part of the Mattermost Org submit this PR in the upstream.\n /cc @mattermost/core-security", file.GetFilename())
-					s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
-					return
-				}
+	for _, prFile := range prFiles {
+		for _, blackListPath := range s.Config.BlacklistPaths {
+			if prFile.GetFilename() == blackListPath {
+				mlog.Error("File is on the blacklist and will not retrigger circleci to give the contexts", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName))
+				msg := fmt.Sprintf("The file `%s` is in the blacklist and should not be modified from external contributors, please if you are part of the Mattermost Org submit this PR in the upstream.\n /cc @mattermost/core-security", prFile.GetFilename())
+				s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
+				return
 			}
 		}
 	}

--- a/server/circleci.go
+++ b/server/circleci.go
@@ -50,7 +50,7 @@ func (s *Server) triggerCircleCiIfNeeded(pr *model.PullRequest) {
 		for _, blackListPath := range s.Config.BlacklistPaths {
 			if prFile.GetFilename() == blackListPath {
 				mlog.Error("File is on the blacklist and will not retrigger circleci to give the contexts", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName))
-				msg := fmt.Sprintf("The file `%s` is in the blacklist and should not be modified from external contributors, please if you are part of the Mattermost Org submit this PR in the upstream.\n /cc @mattermost/core-security", prFile.GetFilename())
+				msg := fmt.Sprintf("The file `%s` is in the blacklist and should not be modified from external contributors, please if you are part of the Mattermost Org submit this PR in the upstream.\n /cc @mattermost/core-security @mattermost/core-build-engineers", prFile.GetFilename())
 				s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
 				return
 			}


### PR DESCRIPTION
#### Summary
The issue we have is that we were checking the commits for a PR and when doing that it will check the commits that came from a merge (to update the PR with the lastest master or another branch) and in those commits, it might contain the blacklisted file.

So now we are getting the files modified or added for that PR, it will return only the files in the PR and not the merge commits.