### PR TITLE
Increase the context timeout for the ios building. #4047

### DIFF
--- a/server/build_mobile_apps.go
+++ b/server/build_mobile_apps.go
@@ -37,7 +37,7 @@ func (s *Server) buildMobileApp(pr *model.PullRequest) {
 		s.createRef(pr, ref)
 		s.sendGitHubComment(prRepoOwner, prRepoName, prNumber, s.Config.BuildMobileAppInitMessage)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
 		defer cancel()
 		s.build(ctx, pr, s.Config.Org)
 


### PR DESCRIPTION
#### Summary
Context with timeout for building the IOS app is too low. Increased now to 2 hours.  

#### Ticket Link
https://github.com/mattermost/mattermost-mobile/pull/4047

![Screenshot from 2020-03-19 18-31-35](https://user-images.githubusercontent.com/9913860/77096706-fecb2000-6a0f-11ea-8d6b-952f15559b24.png)


