### PR TITLE
Trigger ee tests with appropriate ee branch or fallback to base branch. 

### DIFF
--- a/server/circleci.go
+++ b/server/circleci.go
@@ -108,7 +108,7 @@ type PipelineTriggeredResponse struct {
 
 func (s *Server) triggerEnterprisePipeline(ctx context.Context, pr *model.PullRequest, info *EETriggerInfo) (*PipelineTriggeredResponse, error) {
 	body := strings.NewReader(
-		`branch=` + info.BaseBranch +
+		`branch=` + info.EEBranch +
 			`&parameters[tbs_sha]=` + pr.Sha +
 			`&parameters[tbs_pr]=` + strconv.Itoa(pr.Number) +
 			`&parameters[tbs_server_owner]=` + info.ServerOwner +

--- a/server/enterprise.go
+++ b/server/enterprise.go
@@ -53,19 +53,20 @@ func (s *Server) triggerEnterpriseTests(pr *model.PullRequest) {
 
 type EETriggerInfo struct {
 	BaseBranch   string
+	EEBranch     string
 	ServerOwner  string
 	ServerBranch string
 	WebappOwner  string
 	WebappBranch string
 }
 
-func (s *Server) getPRInfo(ctx context.Context, pr *model.PullRequest) (*EETriggerInfo, error) {
+func (s *Server) getPRInfo(ctx context.Context, pr *model.PullRequest) (info *EETriggerInfo, err error) {
 	clientGitHub := NewGithubClient(s.Config.GithubAccessToken)
 	pullRequest, _, err := clientGitHub.PullRequests.Get(ctx, s.Config.Org, pr.RepoName, pr.Number)
 	if err != nil {
 		return nil, err
 	}
-
+	baseBranch := pullRequest.Base.GetRef()
 	isFork := pullRequest.GetHead().GetRepo().GetFork()
 	var serverOwner string
 	if isFork {
@@ -77,12 +78,26 @@ func (s *Server) getPRInfo(ctx context.Context, pr *model.PullRequest) (*EETrigg
 		return nil, fmt.Errorf("owner of server branch not found")
 	}
 
-	webappOwner, webappBranch, err := s.findWebappBranch(clientGitHub, ctx, pullRequest)
+	eeBranch, err := s.getBranchWithSameName(ctx, s.Config.Org, s.Config.EnterpriseReponame, pr.Ref)
 	if err != nil {
 		return nil, err
 	}
-	info := &EETriggerInfo{
-		BaseBranch:   *pullRequest.Base.Ref,
+	if eeBranch == "" {
+		eeBranch = baseBranch
+	}
+
+	webappOwner, webappBranch, err := s.getSameBranchInRepo(ctx, pr, s.Config.EnterpriseWebappReponame)
+	if err != nil {
+		return nil, err
+	}
+	if webappBranch == "" {
+		webappOwner = s.Config.Org
+		webappBranch = baseBranch
+	}
+
+	info = &EETriggerInfo{
+		BaseBranch:   baseBranch,
+		EEBranch:     eeBranch,
 		ServerOwner:  serverOwner,
 		ServerBranch: pr.Ref,
 		WebappOwner:  webappOwner,
@@ -91,54 +106,40 @@ func (s *Server) getPRInfo(ctx context.Context, pr *model.PullRequest) (*EETrigg
 	return info, nil
 }
 
-func (s *Server) findWebappBranch(client *github.Client, ctx context.Context, serverPR *github.PullRequest) (string, string, error) {
-	serverBranch := serverPR.GetHead().GetRef()
-	destinationServerBranch := serverPR.GetBase().GetRef()
+func (s *Server) getBranchWithSameName(ctx context.Context, remote string, repo string, ref string) (branch string, err error) {
+	clientGitHub := NewGithubClient(s.Config.GithubAccessToken)
+	ghBranch, r, err := clientGitHub.Repositories.GetBranch(ctx, remote, repo, ref)
+	if err != nil {
+		if r == nil {
+			return "", err
+		}
+		if r.StatusCode != http.StatusNotFound {
+			return "", err
+		}
+		return "", nil // do not err if branch is not found
+	}
+	if ghBranch == nil {
+		return "", fmt.Errorf("unexpected failure case")
+	}
+	return ghBranch.GetName(), nil
+}
 
-	owner, webappBranch, err := s.getWebappBranchWithSameName(client, ctx, serverPR)
+func (s *Server) getSameBranchInRepo(ctx context.Context, serverPR *model.PullRequest, repo string) (owner string, branch string, err error) {
+	forkBranch, err := s.getBranchWithSameName(ctx, serverPR.Username, repo, serverPR.Ref)
 	if err != nil {
 		return "", "", err
 	}
-
-	if webappBranch == "" {
-		mlog.Debug("Setting base ref of server as webapp branch", mlog.Int("pr", serverPR.GetNumber()), mlog.String("ref", serverBranch))
-		return s.Config.Org, destinationServerBranch, nil
-	}
-
-	return owner, webappBranch, nil
-}
-
-func (s *Server) getWebappBranchWithSameName(client *github.Client, ctx context.Context, serverPR *github.PullRequest) (owner string, branch string, err error) {
-	prAuthor := serverPR.GetUser().GetLogin()
-	ref := serverPR.GetHead().GetRef()
-	forkBranch, r, err := client.Repositories.GetBranch(ctx, prAuthor, s.Config.EnterpriseWebappReponame, ref)
-	if err != nil {
-		if r == nil {
-			return "", "", err
-		}
-
-		if r.StatusCode != http.StatusNotFound {
-			return "", "", err
-		}
-
-		upstreamBranch, r, err := client.Repositories.GetBranch(ctx, s.Config.Org, s.Config.EnterpriseWebappReponame, ref)
+	if forkBranch == "" {
+		upstreamBranch, err := s.getBranchWithSameName(ctx, s.Config.Org, repo, serverPR.Ref)
 		if err != nil {
-			if r == nil {
-				return "", "", err
-			}
-
-			if r.StatusCode != http.StatusNotFound {
-				return "", "", err
-			}
-			return s.Config.Org, serverPR.GetBase().GetRef(), nil
+			return "", "", err
 		}
-
-		owner := s.Config.Org
-		mlog.Debug("Found upstream webapp branch", mlog.String("owner", owner), mlog.String("branch", upstreamBranch.GetName()))
-		return owner, upstreamBranch.GetName(), nil
+		if upstreamBranch == forkBranch {
+			return s.Config.Org, "", nil
+		}
+		return s.Config.Org, upstreamBranch, nil
 	}
-	mlog.Debug("Found webapp branch", mlog.String("owner", prAuthor), mlog.String("branch", forkBranch.GetName()))
-	return prAuthor, forkBranch.GetName(), nil
+	return serverPR.Username, forkBranch, nil
 }
 
 func (s *Server) createEnterpriseTestsPendingStatus(ctx context.Context, pr *model.PullRequest) {
@@ -171,16 +172,6 @@ func (s *Server) createEnterpriseTestsErrorStatus(ctx context.Context, pr *model
 	s.createRepoStatus(ctx, pr, enterpriseErrorStatus)
 	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number,
 		"Failed running enterprise tests. @mattermost/core-build-engineers have been notified. Error:  \n```"+err.Error()+"```")
-}
-
-func (s *Server) succeedOutDatedJenkinsStatuses(ctx context.Context, pr *model.PullRequest) {
-	enterpriseStatus := &github.RepoStatus{
-		State:       github.String("success"),
-		Context:     github.String("continuous-integration/jenkins/pr-merge"),
-		Description: github.String("Outdated check"),
-		TargetURL:   github.String(""),
-	}
-	s.createRepoStatus(ctx, pr, enterpriseStatus)
 }
 
 func (s *Server) succeedEEStatuses(ctx context.Context, pr *model.PullRequest, desc string) {

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -116,8 +116,6 @@ func (s *Server) handlePullRequestEvent(event *PullRequestEvent) {
 		if pr.RepoName == s.Config.EnterpriseTriggerReponame {
 			s.createEnterpriseTestsPendingStatus(context.TODO(), pr)
 			go s.triggerEETestsForOrgMembers(pr)
-			// todo: remove after build.mattermost.com is gone
-			s.succeedOutDatedJenkinsStatuses(context.TODO(), pr)
 		}
 
 		if s.isBlockPRMergeInLabels(pr.Labels) {

--- a/server/server.go
+++ b/server/server.go
@@ -27,9 +27,10 @@ import (
 
 // Server is the mattermod server.
 type Server struct {
-	Config *ServerConfig
-	Store  store.Store
-	Router *mux.Router
+	Config       *ServerConfig
+	Store        store.Store
+	Router       *mux.Router
+	GithubClient *github.Client
 
 	Builds buildsInterface
 
@@ -63,6 +64,7 @@ func New(config *ServerConfig) *Server {
 		StartTime: time.Now(),
 	}
 
+	s.GithubClient = NewGithubClient(s.Config.GithubAccessToken)
 	s.Builds = &Builds{}
 	if os.Getenv(buildOverride) != "" {
 		mlog.Warn("Using mocked build tools")


### PR DESCRIPTION
#### Summary
Triggering the ee tests from a server PR will look for the same named enterprise branch, if this branch exists in the upstream. 
Refactors the the branching logic. 
Removes the jenkins github status auto succeed. 

#### Ticket Link

