### PR TITLE
MM-26379: remove duplicate os.Interrupt signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ mattermod
 mattermod.log
 vendor
 
+# Config file
+config/config-mattermod.json
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/mattermod.go
+++ b/mattermod.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/mattermost/mattermost-mattermod/server"
 	"github.com/mattermost/mattermost-server/v5/mlog"
@@ -72,6 +73,6 @@ func main() {
 
 	c.Start()
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt, os.Interrupt)
+	signal.Notify(sig, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	<-sig
 }


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
We were listening to the same signal. This PR fixes that
to listen for other appropriate signals.

We make one more small, unrelated change to add the config file
to .gitignore.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-26379
