### PR TITLE
MM-26419: make store methods synchronous

### DIFF
--- a/server/auto_merge.go
+++ b/server/auto_merge.go
@@ -14,13 +14,11 @@ import (
 
 func (s *Server) AutoMergePR() {
 	mlog.Info("Starting the process to auto merge PRs")
-	var prs []*model.PullRequest
-	result := <-s.Store.PullRequest().ListOpen()
-	if result.Err != nil {
-		mlog.Error(result.Err.Error())
+	prs, err := s.Store.PullRequest().ListOpen()
+	if err != nil {
+		mlog.Error(err.Error())
 		return
 	}
-	prs = result.Data.([]*model.PullRequest)
 
 	for _, pr := range prs {
 		if !s.isAutoMergeLabelInLabels(pr.Labels) {

--- a/server/builds.go
+++ b/server/builds.go
@@ -67,14 +67,13 @@ func (b *Builds) waitForImage(ctx context.Context, s *Server, reg *registry.Regi
 		case <-ctx.Done():
 			return pr, errors.New("timed out waiting for image to publish")
 		case <-time.After(10 * time.Second):
-			result := <-s.Store.PullRequest().Get(pr.RepoOwner, pr.RepoName, pr.Number)
-			if result.Err != nil {
-				return pr, errors.Wrap(result.Err, "unable to get updated PR from Mattermod database")
+			var appErr *model.AppError
+			pr, appErr = s.Store.PullRequest().Get(pr.RepoOwner, pr.RepoName, pr.Number)
+			if appErr != nil {
+				return nil, errors.Wrap(appErr, "unable to get updated PR from Mattermod database")
 			}
 
 			// Update the PR in case the build link has changed because of a new commit
-			pr = result.Data.(*model.PullRequest)
-
 			desiredTag := b.getInstallationVersion(pr)
 			image := "mattermost/mattermost-enterprise-edition"
 
@@ -99,13 +98,13 @@ func (b *Builds) waitForBuild(ctx context.Context, s *Server, client *jenkins.Je
 		case <-ctx.Done():
 			return pr, errors.New("timed out waiting for build to finish")
 		case <-time.After(30 * time.Second):
-			result := <-s.Store.PullRequest().Get(pr.RepoOwner, pr.RepoName, pr.Number)
-			if result.Err != nil {
-				return pr, errors.Wrap(result.Err, "unable to get updated PR from Mattermod database")
+			var appErr *model.AppError
+			pr, appErr = s.Store.PullRequest().Get(pr.RepoOwner, pr.RepoName, pr.Number)
+			if appErr != nil {
+				return nil, errors.Wrap(appErr, "unable to get updated PR from Mattermod database")
 			}
 
 			// Update the PR in case the build link has changed because of a new commit
-			pr = result.Data.(*model.PullRequest)
 			var err error
 			pr, err = s.GetUpdateChecks(pr.RepoOwner, pr.RepoName, pr.Number)
 			if err != nil {

--- a/server/github.go
+++ b/server/github.go
@@ -78,8 +78,8 @@ func (s *Server) GetPullRequestFromGithub(pullRequest *github.PullRequest) (*mod
 
 	pr.Labels = labelsToStringArray(labels)
 
-	if result := <-s.Store.PullRequest().Save(pr); result.Err != nil {
-		mlog.Error(result.Err.Error())
+	if _, err := s.Store.PullRequest().Save(pr); err != nil {
+		mlog.Error(err.Error())
 	}
 
 	return pr, nil
@@ -168,8 +168,8 @@ func (s *Server) GetUpdateChecks(owner, repoName string, prNumber int) (*model.P
 		return nil, err
 	}
 
-	if result := <-s.Store.PullRequest().Save(pr); result.Err != nil {
-		mlog.Error(result.Err.Error())
+	if _, err := s.Store.PullRequest().Save(pr); err != nil {
+		mlog.Error(err.Error())
 	}
 
 	return pr, nil

--- a/server/issue.go
+++ b/server/issue.go
@@ -28,20 +28,18 @@ func (s *Server) handleIssueEvent(event *PullRequestEvent) {
 }
 
 func (s *Server) checkIssueForChanges(issue *model.Issue) {
-	result := <-s.Store.Issue().Get(issue.RepoOwner, issue.RepoName, issue.Number)
-	if result.Err != nil {
-		mlog.Error(result.Err.Error())
+	oldIssue, err := s.Store.Issue().Get(issue.RepoOwner, issue.RepoName, issue.Number)
+	if err != nil {
+		mlog.Error(err.Error())
 		return
 	}
 
-	if result.Data == nil {
-		if resultSave := <-s.Store.Issue().Save(issue); resultSave.Err != nil {
-			mlog.Error(resultSave.Err.Error())
+	if oldIssue == nil {
+		if _, err := s.Store.Issue().Save(issue); err != nil {
+			mlog.Error(err.Error())
 		}
 		return
 	}
-
-	oldIssue := result.Data.(*model.Issue)
 
 	hasChanges := false
 
@@ -69,8 +67,8 @@ func (s *Server) checkIssueForChanges(issue *model.Issue) {
 	if hasChanges {
 		mlog.Info("issue has changes", mlog.Int("issue", issue.Number))
 
-		if result := <-s.Store.Issue().Save(issue); result.Err != nil {
-			mlog.Error(result.Err.Error())
+		if _, err := s.Store.Issue().Save(issue); err != nil {
+			mlog.Error(err.Error())
 			return
 		}
 	}

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -100,18 +100,17 @@ func (s *Server) handlePullRequestEvent(event *PullRequestEvent) {
 
 		// TODO: remove the old test server code
 		if s.isSpinMintLabel(*event.Label.Name) {
-			result := <-s.Store.Spinmint().Get(pr.Number, pr.RepoName)
-			if result.Err != nil {
-				mlog.Error("Unable to get the test server information.", mlog.String("pr_error", result.Err.Error()))
+			spinmint, err := s.Store.Spinmint().Get(pr.Number, pr.RepoName)
+			if err != nil {
+				mlog.Error("Unable to get the test server information.", mlog.String("pr_error", err.Error()))
 				break
 			}
 
-			if result.Data == nil {
-				mlog.Info("Nothing to do. There is not test server for this PR", mlog.Int("pr", pr.Number))
+			if spinmint == nil {
+				mlog.Info("Nothing to do. There is no test server for this PR", mlog.Int("pr", pr.Number))
 				break
 			}
 
-			spinmint := result.Data.(*model.Spinmint)
 			mlog.Info("test server instance", mlog.String("test server", spinmint.InstanceID))
 			mlog.Info("Will destroy the test server for a merged/closed PR.")
 			s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.DestroyedSpinmintMessage)
@@ -137,18 +136,17 @@ func (s *Server) handlePullRequestEvent(event *PullRequestEvent) {
 		go s.checkIfNeedCherryPick(pr)
 		go s.CleanUpLabels(pr)
 
-		result := <-s.Store.Spinmint().Get(pr.Number, pr.RepoName)
-		if result.Err != nil {
-			mlog.Error("Unable to get the spinmint information.", mlog.String("pr_error", result.Err.Error()))
+		spinmint, err := s.Store.Spinmint().Get(pr.Number, pr.RepoName)
+		if err != nil {
+			mlog.Error("Unable to get the spinmint information.", mlog.String("pr_error", err.Error()))
 			break
 		}
 
-		if result.Data == nil {
+		if spinmint == nil {
 			mlog.Info("Nothing to do. There is no Spinmint for this PR", mlog.Int("pr", pr.Number))
 			break
 		}
 
-		spinmint := result.Data.(*model.Spinmint)
 		mlog.Info("Spinmint instance", mlog.String("spinmint", spinmint.InstanceID))
 		mlog.Info("Will destroy the spinmint for a merged/closed PR.")
 
@@ -162,15 +160,15 @@ func (s *Server) handlePullRequestEvent(event *PullRequestEvent) {
 }
 
 func (s *Server) checkPullRequestForChanges(pr *model.PullRequest) {
-	result := <-s.Store.PullRequest().Get(pr.RepoOwner, pr.RepoName, pr.Number)
-	if result.Err != nil {
-		mlog.Error(result.Err.Error())
+	oldPr, err := s.Store.PullRequest().Get(pr.RepoOwner, pr.RepoName, pr.Number)
+	if err != nil {
+		mlog.Error(err.Error())
 		return
 	}
 
-	if result.Data == nil {
-		if resultSave := <-s.Store.PullRequest().Save(pr); resultSave.Err != nil {
-			mlog.Error(resultSave.Err.Error())
+	if oldPr == nil {
+		if _, err := s.Store.PullRequest().Save(pr); err != nil {
+			mlog.Error(err.Error())
 		}
 
 		for _, label := range pr.Labels {
@@ -180,7 +178,6 @@ func (s *Server) checkPullRequestForChanges(pr *model.PullRequest) {
 		return
 	}
 
-	oldPr := result.Data.(*model.PullRequest)
 	prHasChanges := false
 
 	for _, label := range pr.Labels {
@@ -241,8 +238,8 @@ func (s *Server) checkPullRequestForChanges(pr *model.PullRequest) {
 
 	if prHasChanges {
 		mlog.Info("pr has changes", mlog.Int("pr", pr.Number))
-		if result := <-s.Store.PullRequest().Save(pr); result.Err != nil {
-			mlog.Error(result.Err.Error())
+		if _, err := s.Store.PullRequest().Save(pr); err != nil {
+			mlog.Error(err.Error())
 			return
 		}
 	}
@@ -312,18 +309,17 @@ func (s *Server) handlePRUnlabeled(pr *model.PullRequest, removedLabel string) {
 		// Old comments created by Mattermod user will be deleted here.
 		s.removeOldComments(comments, pr)
 
-		result := <-s.Store.Spinmint().Get(pr.Number, pr.RepoName)
-		if result.Err != nil {
-			mlog.Error("Unable to get the test server information.", mlog.String("pr_error", result.Err.Error()))
+		spinmint, err := s.Store.Spinmint().Get(pr.Number, pr.RepoName)
+		if err != nil {
+			mlog.Error("Unable to get the test server information.", mlog.String("pr_error", err.Error()))
 			return
 		}
 
-		if result.Data == nil {
+		if spinmint == nil {
 			mlog.Info("Nothing to do. There is not test server for this PR", mlog.Int("pr", pr.Number))
 			return
 		}
 
-		spinmint := result.Data.(*model.Spinmint)
 		mlog.Info("test server instance", mlog.String("test server", spinmint.InstanceID))
 		mlog.Info("Will destroy the test server for a merged/closed PR.")
 
@@ -361,13 +357,11 @@ func (s *Server) removeOldComments(comments []*github.IssueComment, pr *model.Pu
 
 func (s *Server) CheckPRActivity() {
 	mlog.Info("Checking if need to Stale a Pull request")
-	var prs []*model.PullRequest
-	result := <-s.Store.PullRequest().ListOpen()
-	if result.Err != nil {
-		mlog.Error(result.Err.Error())
+	prs, err := s.Store.PullRequest().ListOpen()
+	if err != nil {
+		mlog.Error(err.Error())
 		return
 	}
-	prs = result.Data.([]*model.PullRequest)
 
 	for _, pr := range prs {
 		pull, _, errPull := s.GithubClient.PullRequests.Get(context.Background(), pr.RepoOwner, pr.RepoName, pr.Number)
@@ -426,12 +420,11 @@ func (s *Server) CheckPRActivity() {
 func (s *Server) CleanOutdatedPRs() {
 	mlog.Info("Cleaning outdated PRs in the mattermod database....")
 
-	result := <-s.Store.PullRequest().ListOpen()
-	if result.Err != nil {
-		mlog.Error(result.Err.Error())
+	prs, err := s.Store.PullRequest().ListOpen()
+	if err != nil {
+		mlog.Error(err.Error())
 		return
 	}
-	prs := result.Data.([]*model.PullRequest)
 
 	mlog.Info("Processing PRs", mlog.Int("PRs Count", len(prs)))
 
@@ -450,8 +443,8 @@ func (s *Server) CleanOutdatedPRs() {
 		if pull.GetState() == model.StateClosed {
 			mlog.Info("PR is closed, updating the status in the database", mlog.String("RepoOwner", pr.RepoOwner), mlog.String("RepoName", pr.RepoName), mlog.Int("PRNumber", pr.Number))
 			pr.State = pull.GetState()
-			if result := <-s.Store.PullRequest().Save(pr); result.Err != nil {
-				mlog.Error(result.Err.Error())
+			if _, err := s.Store.PullRequest().Save(pr); err != nil {
+				mlog.Error(err.Error())
 			}
 		} else {
 			mlog.Info("Nothing to do", mlog.String("RepoOwner", pr.RepoOwner), mlog.String("RepoName", pr.RepoName), mlog.Int("PRNumber", pr.Number))

--- a/server/spinmint.go
+++ b/server/spinmint.go
@@ -316,7 +316,7 @@ func (s *Server) storeSpinmintInfo(spinmint *model.Spinmint) {
 }
 
 func (s *Server) removeTestServerFromDB(instanceID string) {
-	if _, err := s.Store.Spinmint().Delete(instanceID); err != nil {
+	if err := s.Store.Spinmint().Delete(instanceID); err != nil {
 		mlog.Error(err.Error())
 	}
 }

--- a/server/spinmint.go
+++ b/server/spinmint.go
@@ -43,13 +43,13 @@ func (s *Server) waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServ
 	}
 
 	var instance *ec2.Instance
-	result := <-s.Store.Spinmint().Get(pr.Number, pr.RepoName)
-	if result.Err != nil {
-		mlog.Error("Unable to get the spinmint information. Will not build the spinmint", mlog.String("pr_error", result.Err.Error()))
+	spinmint, appErr := s.Store.Spinmint().Get(pr.Number, pr.RepoName)
+	if appErr != nil {
+		mlog.Error("Unable to get the spinmint information. Will not build the spinmint", mlog.String("pr_error", appErr.Error()))
 		return
 	}
 
-	if result.Data == nil {
+	if spinmint == nil {
 		mlog.Error("No spinmint for this PR in the Database. will start a fresh one.")
 		var errInstance error
 		instance, errInstance = s.setupSpinmint(pr, repo, upgradeServer)
@@ -58,7 +58,7 @@ func (s *Server) waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServ
 			s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, s.Config.SetupSpinmintFailedMessage)
 			return
 		}
-		spinmint := &model.Spinmint{
+		spinmint = &model.Spinmint{
 			InstanceID: *instance.InstanceId,
 			RepoOwner:  pr.RepoOwner,
 			RepoName:   pr.RepoName,
@@ -67,7 +67,6 @@ func (s *Server) waitForBuildAndSetupSpinmint(pr *model.PullRequest, upgradeServ
 		}
 		s.storeSpinmintInfo(spinmint)
 	} else {
-		spinmint := result.Data.(*model.Spinmint)
 		instance = &ec2.Instance{
 			InstanceId: aws.String(spinmint.InstanceID),
 		}
@@ -284,11 +283,11 @@ func (s *Server) updateRoute53Subdomain(name, target, action string) error {
 func (s *Server) CheckTestServerLifeTime() {
 	mlog.Info("Checking Test Server lifetime...")
 
-	result := <-s.Store.Spinmint().List()
-	if result.Err != nil {
-		mlog.Error("Unable to get updated PR while waiting for test server", mlog.String("testServer_error", result.Err.Error()))
+	testServers, err := s.Store.Spinmint().List()
+	if err != nil {
+		mlog.Error("Unable to get updated PR while waiting for test server", mlog.String("testServer_error", err.Error()))
+		return
 	}
-	testServers := result.Data.([]*model.Spinmint)
 
 	for _, testServer := range testServers {
 		mlog.Info("Check if need destroy Test Server for PR", mlog.String("instance", testServer.InstanceID), mlog.Int("TestServer", testServer.Number), mlog.String("repo_owner", testServer.RepoOwner), mlog.String("repo_name", testServer.RepoName))
@@ -311,14 +310,14 @@ func (s *Server) CheckTestServerLifeTime() {
 }
 
 func (s *Server) storeSpinmintInfo(spinmint *model.Spinmint) {
-	if result := <-s.Store.Spinmint().Save(spinmint); result.Err != nil {
-		mlog.Error(result.Err.Error())
+	if _, err := s.Store.Spinmint().Save(spinmint); err != nil {
+		mlog.Error(err.Error())
 	}
 }
 
 func (s *Server) removeTestServerFromDB(instanceID string) {
-	if result := <-s.Store.Spinmint().Delete(instanceID); result.Err != nil {
-		mlog.Error(result.Err.Error())
+	if _, err := s.Store.Spinmint().Delete(instanceID); err != nil {
+		mlog.Error(err.Error())
 	}
 }
 

--- a/store/sql_spinmint.store.go
+++ b/store/sql_spinmint.store.go
@@ -75,14 +75,12 @@ func (s SQLSpinmintStore) Get(prNumber int, repoName string) (*model.Spinmint, *
 	return &spinmint, nil
 }
 
-func (s SQLSpinmintStore) Delete(instanceID string) ([]*model.Spinmint, *model.AppError) {
-	var spinmints []*model.Spinmint
-	if _, err := s.GetReplica().Select(&spinmints,
-		`DELETE FROM
+func (s SQLSpinmintStore) Delete(instanceID string) *model.AppError {
+	if _, err := s.GetReplica().Exec(`DELETE FROM
         Spinmint
       WHERE
         InstanceId = :InstanceID`, map[string]interface{}{"InstanceID": instanceID}); err != nil {
-		return nil, model.NewLocAppError("SQLSpinmintStore.Delete", "Could not list spinmint", nil, err.Error())
+		return model.NewLocAppError("SQLSpinmintStore.Delete", "Could not list spinmint", nil, err.Error())
 	}
-	return spinmints, nil
+	return nil
 }

--- a/store/sql_spinmint.store.go
+++ b/store/sql_spinmint.store.go
@@ -29,102 +29,60 @@ func (s SQLSpinmintStore) CreateIndexesIfNotExists() {
 	s.CreateColumnIfNotExists("Spinmint", "InstanceId", "varchar(128)", "varchar(128)", "")
 }
 
-func (s SQLSpinmintStore) Save(spinmint *model.Spinmint) Channel {
-	storeChannel := make(Channel)
-
-	go func() {
-		result := Result{}
-
-		if err := s.GetMaster().Insert(spinmint); err != nil {
-			if _, err := s.GetMaster().Update(spinmint); err != nil {
-				result.Err = model.NewLocAppError("SQLSpinmintStore.Save", "Could not insert or update spinmint", nil,
-					fmt.Sprintf("instanceid=%v, owner=%v, name=%v, number=%v, err=%v", spinmint.InstanceID, spinmint.RepoOwner, spinmint.RepoName, spinmint.Number, err.Error()))
-			}
+func (s SQLSpinmintStore) Save(spinmint *model.Spinmint) (*model.Spinmint, *model.AppError) {
+	if err := s.GetMaster().Insert(spinmint); err != nil {
+		if _, err := s.GetMaster().Update(spinmint); err != nil {
+			return nil, model.NewLocAppError("SQLSpinmintStore.Save",
+				"Could not insert or update spinmint",
+				nil,
+				fmt.Sprintf("instanceid=%v, owner=%v, name=%v, number=%v, err=%v",
+					spinmint.InstanceID, spinmint.RepoOwner, spinmint.RepoName, spinmint.Number, err.Error()),
+			)
 		}
-
-		if result.Err == nil {
-			result.Data = spinmint
-		}
-
-		storeChannel <- result
-		close(storeChannel)
-	}()
-
-	return storeChannel
+	}
+	return spinmint, nil
 }
 
-func (s SQLSpinmintStore) List() Channel {
-	storeChannel := make(Channel)
-
-	go func() {
-		result := Result{}
-
-		var spinmint []*model.Spinmint
-		if _, err := s.GetReplica().Select(&spinmint,
-			`SELECT
+func (s SQLSpinmintStore) List() ([]*model.Spinmint, *model.AppError) {
+	var spinmints []*model.Spinmint
+	_, err := s.GetReplica().Select(&spinmints,
+		`SELECT
         *
       FROM
-        Spinmint`); err != nil {
-			result.Err = model.NewLocAppError("SQLSpinmintStore.List", "Could not list spinmint", nil, err.Error())
-		} else {
-			result.Data = spinmint
-		}
-
-		storeChannel <- result
-		close(storeChannel)
-	}()
-
-	return storeChannel
+        Spinmint`)
+	if err != nil {
+		return nil, model.NewLocAppError("SQLSpinmintStore.List", "Could not list spinmint", nil, err.Error())
+	}
+	return spinmints, nil
 }
 
-func (s SQLSpinmintStore) Get(prNumber int, repoName string) Channel {
-	storeChannel := make(Channel)
-
-	go func() {
-		result := Result{}
-
-		var spinmint model.Spinmint
-		if err := s.GetReplica().SelectOne(&spinmint,
-			`SELECT * FROM
+func (s SQLSpinmintStore) Get(prNumber int, repoName string) (*model.Spinmint, *model.AppError) {
+	var spinmint model.Spinmint
+	if err := s.GetReplica().SelectOne(&spinmint,
+		`SELECT * FROM
         Spinmint
       WHERE
         Number = :prNumber AND RepoName = :repoName`, map[string]interface{}{"prNumber": prNumber, "repoName": repoName}); err != nil {
-			if err != sql.ErrNoRows {
-				result.Err = model.NewLocAppError("SQLSpinmintStore.Get", "Could not get the spinmint", nil,
-					fmt.Sprintf("owner=%v, name=%v, number=%v, instanceid=%v, err=%v", spinmint.RepoOwner, spinmint.RepoName, spinmint.Number, spinmint.InstanceID, err.Error()))
-			} else {
-				result.Data = nil
-			}
-		} else {
-			result.Data = &spinmint
+		if err != sql.ErrNoRows {
+			return nil, model.NewLocAppError("SQLSpinmintStore.Get",
+				"Could not get the spinmint",
+				nil,
+				fmt.Sprintf("owner=%v, name=%v, number=%v, instanceid=%v, err=%v", spinmint.RepoOwner, spinmint.RepoName, spinmint.Number, spinmint.InstanceID, err.Error()),
+			)
 		}
-
-		storeChannel <- result
-		close(storeChannel)
-	}()
-
-	return storeChannel
+		return nil, nil // row not found.
+	}
+	return &spinmint, nil
 }
 
-func (s SQLSpinmintStore) Delete(instanceID string) Channel {
-	storeChannel := make(Channel)
-	go func() {
-		result := Result{}
-
-		var spinmint []*model.Spinmint
-		if _, err := s.GetReplica().Select(&spinmint,
-			`DELETE FROM
+func (s SQLSpinmintStore) Delete(instanceID string) ([]*model.Spinmint, *model.AppError) {
+	var spinmints []*model.Spinmint
+	if _, err := s.GetReplica().Select(&spinmints,
+		`DELETE FROM
         Spinmint
       WHERE
         InstanceId = :InstanceID`, map[string]interface{}{"InstanceID": instanceID}); err != nil {
-			result.Err = model.NewLocAppError("SQLSpinmintStore.Delete", "Could not list spinmint", nil, err.Error())
-		} else {
-			result.Data = spinmint
-		}
-
-		storeChannel <- result
-		close(storeChannel)
-	}()
-
-	return storeChannel
+		return nil, model.NewLocAppError("SQLSpinmintStore.Delete", "Could not list spinmint", nil, err.Error())
+	}
+	return spinmints, nil
 }

--- a/store/store.go
+++ b/store/store.go
@@ -28,7 +28,7 @@ type IssueStore interface {
 
 type SpinmintStore interface {
 	Save(spinmint *model.Spinmint) (*model.Spinmint, *model.AppError)
-	Delete(instanceID string) ([]*model.Spinmint, *model.AppError)
+	Delete(instanceID string) *model.AppError
 	Get(prNumber int, repoName string) (*model.Spinmint, *model.AppError)
 	List() ([]*model.Spinmint, *model.AppError)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -4,27 +4,8 @@
 package store
 
 import (
-	"time"
-
 	"github.com/mattermost/mattermost-mattermod/model"
 )
-
-type Result struct {
-	Data interface{}
-	Err  *model.AppError
-}
-
-type Channel chan Result
-
-func Must(sc Channel) interface{} {
-	r := <-sc
-	if r.Err != nil {
-		time.Sleep(time.Second)
-		panic(r.Err)
-	}
-
-	return r.Data
-}
 
 type Store interface {
 	PullRequest() PullRequestStore
@@ -35,19 +16,19 @@ type Store interface {
 }
 
 type PullRequestStore interface {
-	Save(pr *model.PullRequest) Channel
-	Get(repoOwner, repoName string, number int) Channel
-	ListOpen() Channel
+	Save(pr *model.PullRequest) (*model.PullRequest, *model.AppError)
+	Get(repoOwner, repoName string, number int) (*model.PullRequest, *model.AppError)
+	ListOpen() ([]*model.PullRequest, *model.AppError)
 }
 
 type IssueStore interface {
-	Save(issue *model.Issue) Channel
-	Get(repoOwner, repoName string, number int) Channel
+	Save(issue *model.Issue) (*model.Issue, *model.AppError)
+	Get(repoOwner, repoName string, number int) (*model.Issue, *model.AppError)
 }
 
 type SpinmintStore interface {
-	Save(spinmint *model.Spinmint) Channel
-	Delete(instanceID string) Channel
-	Get(prNumber int, repoName string) Channel
-	List() Channel
+	Save(spinmint *model.Spinmint) (*model.Spinmint, *model.AppError)
+	Delete(instanceID string) ([]*model.Spinmint, *model.AppError)
+	Get(prNumber int, repoName string) (*model.Spinmint, *model.AppError)
+	List() ([]*model.Spinmint, *model.AppError)
 }


### PR DESCRIPTION
Mattermod still uses the old architecture of spawning a goroutine
for each store method and waiting for it. The server codebase has migrated from it,
but this is still lagging behind.

This PR makes the change to convert all store methods to be synchronous.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-26419