### PR TITLE
[MM26383] server/server_test: remove globals and slim down tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ build:
 package: build
 	tar -C dist -czf dist/mattermod.tar.gz mattermod
 
-## Runs tests. For local usage, run `make test CONFIG_TEST="-config=config-mattermod.test-local.json"`
+## Runs tests.
 test:
 	@echo Running Go tests
-	$(GO) test $(PACKAGES) $(CONFIG_TEST)
+	$(GO) test $(PACKAGES)
 	@echo test success
 
 

--- a/server/server.go
+++ b/server/server.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -39,7 +40,7 @@ type Server struct {
 }
 
 type pingResponse struct {
-	Uptime time.Duration `json:"uptime"`
+	Uptime string `json:"uptime"`
 }
 
 const (
@@ -183,7 +184,8 @@ func (s *Server) initializeRouter() {
 }
 
 func (s *Server) ping(w http.ResponseWriter, r *http.Request) {
-	err := json.NewEncoder(w).Encode(pingResponse{Uptime: time.Since(s.StartTime)})
+	uptime := fmt.Sprintf("%v", time.Since(s.StartTime))
+	err := json.NewEncoder(w).Encode(pingResponse{Uptime: uptime})
 	if err != nil {
 		mlog.Error("Failed to write ping", mlog.Err(err))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -27,6 +27,8 @@ func TestPing(t *testing.T) {
 
 	res, err := http.Get(ts.URL)
 	require.NoError(t, err)
+	defer res.Body.Close()
+
 	bytes, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
 	bytesLoader := gojsonschema.NewBytesLoader(bytes)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4,17 +4,13 @@
 package server
 
 import (
-	"io/ioutil"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/xeipuuv/gojsonschema"
 )
 
 func TestPing(t *testing.T) {
@@ -29,20 +25,9 @@ func TestPing(t *testing.T) {
 	require.NoError(t, err)
 	defer res.Body.Close()
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	var ping pingResponse
+
+	err = json.NewDecoder(res.Body).Decode(&ping)
 	require.NoError(t, err)
-	bytesLoader := gojsonschema.NewBytesLoader(bytes)
-
-	dir, err := filepath.Abs(filepath.Dir(""))
-	assert.NoError(t, err)
-
-	jsonLoader := gojsonschema.NewReferenceLoader("file://" + dir + "/schema/ping.schema.json")
-	result, err := gojsonschema.Validate(jsonLoader, bytesLoader)
-	assert.NoError(t, err)
-	assert.True(t, result.Valid())
-	if !result.Valid() {
-		for _, err := range result.Errors() {
-			t.Log(err.Description())
-		}
-	}
+	require.NotZero(t, ping.Uptime)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -30,4 +30,6 @@ func TestPing(t *testing.T) {
 	err = json.NewDecoder(res.Body).Decode(&ping)
 	require.NoError(t, err)
 	require.NotZero(t, ping.Uptime)
+	_, err = time.ParseDuration(ping.Uptime)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
#### Summary
This PR removes global state form `server_test` and also slims down the test to actually test the `ping()` endpoint. There were too much initialization and complexity for only testing a single endpoint. If server is need to be tested, it should be handled in a different test.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26383

