### PR TITLE
[MM-26377] server/builds: remove unnecessary code

### DIFF
--- a/server/builds.go
+++ b/server/builds.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -19,7 +18,6 @@ type Builds struct{}
 
 type buildsInterface interface {
 	getInstallationVersion(pr *model.PullRequest) string
-	dockerRegistryClient(s *Server) (*registry.Registry, error)
 	waitForImage(ctx context.Context, s *Server, reg *registry.Registry, pr *model.PullRequest) (*model.PullRequest, error)
 	buildJenkinsClient(s *Server, pr *model.PullRequest) (*Repository, *jenkins.Jenkins, error)
 	waitForBuild(ctx context.Context, s *Server, client *jenkins.Jenkins, pr *model.PullRequest) (*model.PullRequest, error)
@@ -28,19 +26,6 @@ type buildsInterface interface {
 
 func (b *Builds) getInstallationVersion(pr *model.PullRequest) string {
 	return pr.Sha[0:7]
-}
-
-func (b *Builds) dockerRegistryClient(s *Server) (reg *registry.Registry, err error) {
-	if _, err = url.ParseRequestURI(s.Config.DockerRegistryURL); err != nil {
-		return nil, errors.Wrap(err, "invalid url for docker registry")
-	}
-
-	reg, err = registry.New(s.Config.DockerRegistryURL, s.Config.DockerUsername, s.Config.DockerPassword)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to connect to docker registry")
-	}
-
-	return reg, nil
 }
 
 func (b *Builds) buildJenkinsClient(s *Server, pr *model.PullRequest) (*Repository, *jenkins.Jenkins, error) {

--- a/server/builds_mocked.go
+++ b/server/builds_mocked.go
@@ -22,10 +22,6 @@ func (b *MockedBuilds) buildJenkinsClient(s *Server, pr *model.PullRequest) (*Re
 	return nil, nil, nil
 }
 
-func (b *MockedBuilds) dockerRegistryClient(s *Server) (*registry.Registry, error) {
-	return nil, nil
-}
-
 func (b *MockedBuilds) waitForImage(ctx context.Context, s *Server, reg *registry.Registry, pr *model.PullRequest) (*model.PullRequest, error) {
 	return pr, nil
 }


### PR DESCRIPTION

#### Summary
This PR removes `dockerRegistryClient` code from `server/builds.go` which is not used anywhere.

#### Ticket Link
<!--
https://mattermost.atlassian.net/browse/MM-26382
