### PR TITLE
[MM-26380] Replace manners with standard library shutdown

### DIFF
--- a/mattermod.go
+++ b/mattermod.go
@@ -32,15 +32,15 @@ func main() {
 
 	mlog.Info("Starting Mattermod Server")
 	go func() {
-		if err := s.Start(); err != nil {
-			mlog.Error("Server exited with error", mlog.Err(err))
+		if err2 := s.Start(); err2 != nil {
+			mlog.Error("Server exited with error", mlog.Err(err2))
 			os.Exit(1)
 		}
 	}()
 	defer func() {
 		mlog.Info("Stopping Mattermod Server")
-		if err := s.Stop(); err != nil {
-			mlog.Error("Error while shutting down server", mlog.Err(err))
+		if err2 := s.Stop(); err2 != nil {
+			mlog.Error("Error while shutting down server", mlog.Err(err2))
 			os.Exit(1)
 		}
 	}()

--- a/mattermod.go
+++ b/mattermod.go
@@ -31,12 +31,8 @@ func main() {
 	s := server.New(config)
 
 	mlog.Info("Starting Mattermod Server")
-	go func() {
-		if err2 := s.Start(); err2 != nil {
-			mlog.Error("Server exited with error", mlog.Err(err2))
-			os.Exit(1)
-		}
-	}()
+	s.Start()
+
 	defer func() {
 		mlog.Info("Stopping Mattermod Server")
 		if err2 := s.Stop(); err2 != nil {

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/mattermost/mattermost-mattermod/model"
 	"github.com/mattermost/mattermost-server/v5/mlog"
@@ -135,6 +137,11 @@ func (s *Server) doCherryPick(version string, milestoneNumber *int, pr *model.Pu
 }
 
 func (s *Server) getAssignee(newPRNumber int, pr *model.PullRequest) string {
+	var once sync.Once
+	once.Do(func() {
+		rand.Seed(time.Now().Unix())
+	})
+
 	var assignee string
 	if s.IsOrgMember(pr.Username) {
 		// He/She can review the PR herself/himself

--- a/server/server.go
+++ b/server/server.go
@@ -89,16 +89,16 @@ func New(config *Config) *Server {
 }
 
 // Start starts a server
-func (s *Server) Start() error {
+func (s *Server) Start() {
 	s.RefreshMembers()
-
 	mlog.Info("Listening on", mlog.String("address", s.Config.ListenAddress))
-	err := s.server.ListenAndServe()
-	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		return err
-	}
-
-	return nil
+	go func() {
+		err := s.server.ListenAndServe()
+		if errors.Is(err, http.ErrServerClosed) {
+			return
+		}
+		mlog.Error("Server exited with error", mlog.Err(err))
+	}()
 }
 
 // Stop stops a server


### PR DESCRIPTION
#### Summary
This PR remove `manners` for `http.Server` shutdown. Also moved `rand.Seed()` into more convenient place. Did some cleanup in the server struct.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26380
