### PR TITLE
Allow other user to be the root

### DIFF
--- a/store/sql_store_test.go
+++ b/store/sql_store_test.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultMysqlDSN     = "mattermod:mattermod@tcp(localhost:3306)/mattermost_mattermod_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s\u0026parseTime=true"
 	defaultMysqlUser    = "mattermod"
-	defaultMysqlRootPWD = "mattermod"
+	defaultMysqlRootPWD = "root"
 	defaultMysqlUserPWD = "mattermod"
 	defaultMysqlDB      = "mattermod_test"
 )

--- a/store/sql_store_test.go
+++ b/store/sql_store_test.go
@@ -59,13 +59,14 @@ func getTestSQLStore(t *testing.T) *SQLStore {
 }
 
 func createTempDB(t *testing.T, dbName, dbUser string) {
+	rootUser := getEnv("MYSQL_ROOT_USER", defaultMysqlRootPWD)
 	rootPwd := getEnv("MYSQL_ROOT_PASSWORD", defaultMysqlRootPWD)
 	cfg, err := mysql.ParseDSN(defaultMysqlDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cfg.User = "root"
+	cfg.User = rootUser
 	cfg.Passwd = rootPwd
 	cfg.DBName = "mysql"
 

--- a/store/sql_store_test.go
+++ b/store/sql_store_test.go
@@ -11,11 +11,12 @@ import (
 )
 
 const (
-	defaultMysqlDSN     = "mattermod:mattermod@tcp(localhost:3306)/mattermost_mattermod_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s\u0026parseTime=true"
-	defaultMysqlUser    = "mattermod"
-	defaultMysqlRootPWD = "root"
-	defaultMysqlUserPWD = "mattermod"
-	defaultMysqlDB      = "mattermod_test"
+	defaultMysqlDSN         = "mattermod:mattermod@tcp(localhost:3306)/mattermost_mattermod_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s\u0026parseTime=true"
+	defaultMysqlRootUser    = "root"
+	defaultMysqlRootUserPWD = "root"
+	defaultMysqlUser        = "mattermod"
+	defaultMysqlUserPWD     = "mattermod"
+	defaultMysqlDB          = "mattermod_test"
 )
 
 func getTestSQLStore(t *testing.T) *SQLStore {
@@ -59,8 +60,8 @@ func getTestSQLStore(t *testing.T) *SQLStore {
 }
 
 func createTempDB(t *testing.T, dbName, dbUser string) {
-	rootUser := getEnv("MYSQL_ROOT_USER", defaultMysqlRootPWD)
-	rootPwd := getEnv("MYSQL_ROOT_PASSWORD", defaultMysqlRootPWD)
+	rootUser := getEnv("MYSQL_ROOT_USER", defaultMysqlRootUser)
+	rootPwd := getEnv("MYSQL_ROOT_PASSWORD", defaultMysqlRootUserPWD)
 	cfg, err := mysql.ParseDSN(defaultMysqlDSN)
 	if err != nil {
 		t.Fatal(err)

--- a/store/sql_store_test.go
+++ b/store/sql_store_test.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultMysqlDSN         = "mattermod:mattermod@tcp(localhost:3306)/mattermost_mattermod_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s\u0026parseTime=true"
 	defaultMysqlRootUser    = "root"
-	defaultMysqlRootUserPWD = "root"
+	defaultMysqlRootUserPWD = "mattermod"
 	defaultMysqlUser        = "mattermod"
 	defaultMysqlUserPWD     = "mattermod"
 	defaultMysqlDB          = "mattermod_test"


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR lets define another root user that is different than root to execute the tests.

The motivation behind this PR is that I'm using a docker image for mysql that has the root user in localhost and I've created a mattermod user with admin permissions and I need this changes to make it work:

```
$ MYSQL_ROOT_USER=mattermod MYSQL_ROOT_PASSWORD=mattermod make test
Running Go tests
/usr/local/go/bin/go test github.com/mattermost/mattermost-mattermod/cmd/mattermost-mattermod github.com/mattermost/mattermost-mattermod/model github.com/mattermost/mattermost-mattermod/server github.com/mattermost/mattermost-mattermod/server/mocks github.com/mattermost/mattermost-mattermod/store github.com/mattermost/mattermost-mattermod/store/mocks
?   	github.com/mattermost/mattermost-mattermod/cmd/mattermost-mattermod	[no test files]
?   	github.com/mattermost/mattermost-mattermod/model	[no test files]
ok  	github.com/mattermost/mattermost-mattermod/server	(cached)
?   	github.com/mattermost/mattermost-mattermod/server/mocks	[no test files]
ok  	github.com/mattermost/mattermost-mattermod/store	0.030s
?   	github.com/mattermost/mattermost-mattermod/store/mocks	[no test files]
test success
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

