### PR TITLE
MM-26797: Fix context cancellation on goroutines

### DIFF
--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -55,7 +55,10 @@ func (s *Server) handleCherryPick(ctx context.Context, eventIssueComment IssueCo
 	}
 }
 
-func (s *Server) checkIfNeedCherryPick(ctx context.Context, pr *model.PullRequest) {
+func (s *Server) checkIfNeedCherryPick(pr *model.PullRequest) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout*time.Second)
+	defer cancel()
+
 	prCherryCandidate, _, err := s.GithubClient.PullRequests.Get(ctx, pr.RepoOwner, pr.RepoName, pr.Number)
 	if err != nil {
 		mlog.Error("Error getting the PR info", mlog.Err(err))

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -56,6 +56,9 @@ func (s *Server) handleCherryPick(ctx context.Context, eventIssueComment IssueCo
 }
 
 func (s *Server) checkIfNeedCherryPick(pr *model.PullRequest) {
+	// We create a new context here instead of using the parent one because this is being called from a goroutine.
+	// Ideally, the entire request needs to be handled asynchronously.
+	// See: https://github.com/mattermost/mattermost-mattermod/pull/166.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout*time.Second)
 	defer cancel()
 

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -136,7 +136,7 @@ func (s *Server) handlePullRequestEvent(ctx context.Context, event *PullRequestE
 		}
 	case "closed":
 		mlog.Info("PR was closed", mlog.String("repo", *event.Repo.Name), mlog.Int("pr", event.PRNumber))
-		go s.checkIfNeedCherryPick(ctx, pr)
+		go s.checkIfNeedCherryPick(pr)
 		go s.CleanUpLabels(pr)
 
 		spinmint, err := s.Store.Spinmint().Get(pr.Number, pr.RepoName)


### PR DESCRIPTION
We passed several contexts to goroutines. Therefore when the parent
function returned, the context got cancelled and therefore the running
goroutines would throw an error. To fix this:

- We remove passing the context in checkIfNeedCherryPick. This is not
ideal and every call should take the parent context. The problem is that
a request handler is semi-synchronous. It does some jobs synchronously and
spins of time taking jobs in goroutines without any control of how to shut
them down.

What we need is to make the entire event handler async, and create a context
inside that and run everything synchronously inside that. Until we have that,
we need to make do with this.

- We make createCLAPendingStatus synchronous. This also fixes a long-standing
bug where the CLA check would randomly go to a pending state.

- We move sendGitHubComment to a closure and create a new context. Again, not
ideal but have to bear with this.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-26797
