### PR TITLE
MM-26829: Fix duplicate label removal

### DIFF
--- a/server/auto_merge.go
+++ b/server/auto_merge.go
@@ -101,14 +101,12 @@ func (s *Server) AutoMergePR() error {
 		merged, _, err := s.GithubClient.PullRequests.Merge(ctx, pr.RepoOwner, pr.RepoName, pr.Number, "Automatic Merge", opt)
 		if err != nil {
 			errMsg := fmt.Sprintf("Error while trying to automerge the PR\nErr %s", err.Error())
-			s.removeLabel(ctx, pr.RepoOwner, pr.RepoName, pr.Number, s.Config.AutoPRMergeLabel)
 			s.sendGitHubComment(ctx, pr.RepoOwner, pr.RepoName, pr.Number, errMsg)
 			continue
 		}
 
 		msg = fmt.Sprintf("%s\nSHA: %s", merged.GetMessage(), merged.GetSHA())
 		s.sendGitHubComment(ctx, pr.RepoOwner, pr.RepoName, pr.Number, msg)
-		s.removeLabel(ctx, pr.RepoOwner, pr.RepoName, pr.Number, s.Config.AutoPRMergeLabel)
 	}
 
 	mlog.Info("Done with the process to auto merge PRs")

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -483,6 +483,7 @@ func (s *Server) CleanUpLabels(pr *model.PullRequest) {
 					defer wg.Done()
 					s.removeLabel(ctx, pr.RepoOwner, pr.RepoName, pr.Number, label)
 				}(labelToRemove)
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
There's no need to remove a label after doing auto-merge, because
it already gets removed as part of a cleanup label process when a PR
is closed.

This fixes a race condition where we were trying to remove the same label twice,
generating logs like this:

```
ERRO[2020-07-09T18:54:14.659247+05:30] Error removing the label                      caller="server/github.go:129" error="DELETE https://api.github.com/repos/mattermost/mattermost-server/issues/14970/labels/AutoMerge: 404 Label does not exist []
```

While here, we add a continue statement to quickly move forward.

### Ticket link

https://mattermost.atlassian.net/browse/MM-26820
