### PR TITLE
[MM-26819] server: add some error propogation to handleIssueEvent

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -54,7 +54,7 @@ func (s *Server) checkIssueForChanges(ctx context.Context, issue *model.Issue) e
 		if !hadLabel {
 			mlog.Info("issue added label", mlog.Int("issue", issue.Number), mlog.String("label", label))
 			if err = s.handleIssueLabeled(ctx, issue, label); err != nil {
-			    return fmt.Errorf("could not handle issue label added: %w", err)
+				return fmt.Errorf("could not handle issue label added: %w", err)
 			}
 			hasChanges = true
 		}

--- a/server/issue.go
+++ b/server/issue.go
@@ -53,9 +53,8 @@ func (s *Server) checkIssueForChanges(ctx context.Context, issue *model.Issue) e
 
 		if !hadLabel {
 			mlog.Info("issue added label", mlog.Int("issue", issue.Number), mlog.String("label", label))
-			err = s.handleIssueLabeled(ctx, issue, label)
-			if err != nil {
-				return fmt.Errorf("could not handle issue label added: %w", err)
+			if err = s.handleIssueLabeled(ctx, issue, label); err != nil {
+			    return fmt.Errorf("could not handle issue label added: %w", err)
 			}
 			hasChanges = true
 		}

--- a/server/issue.go
+++ b/server/issue.go
@@ -5,47 +5,41 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/mattermost/mattermost-mattermod/model"
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
-func (s *Server) handleIssueEvent(ctx context.Context, event *PullRequestEvent) {
+func (s *Server) handleIssueEvent(ctx context.Context, event *PullRequestEvent) error {
 	if event == nil || event.Issue == nil {
-		return
+		return errors.New("could not handle issue event: either event or issue is nil")
 	}
 	parts := strings.Split(*event.Issue.HTMLURL, "/")
 
 	mlog.Info("handle issue event", mlog.String("repoUrl", *event.Issue.HTMLURL), mlog.String("Action", event.Action), mlog.Int("PRNumber", event.PRNumber))
 	issue, err := s.GetIssueFromGithub(ctx, parts[len(parts)-4], parts[len(parts)-3], event.Issue)
 	if err != nil {
-		mlog.Error("Error getting the issue from Github", mlog.Err(err))
-		return
+		return fmt.Errorf("error getting the issue from GitHub: %w", err)
 	}
 
-	s.checkIssueForChanges(ctx, issue)
+	return s.checkIssueForChanges(ctx, issue)
 }
 
-func (s *Server) checkIssueForChanges(ctx context.Context, issue *model.Issue) {
+func (s *Server) checkIssueForChanges(ctx context.Context, issue *model.Issue) error {
 	oldIssue, err := s.Store.Issue().Get(issue.RepoOwner, issue.RepoName, issue.Number)
 	if err != nil {
-		mlog.Error(err.Error())
-		return
+		return err
 	}
 
 	if oldIssue == nil {
-		if _, err := s.Store.Issue().Save(issue); err != nil {
-			mlog.Error(err.Error())
-		}
-		return
+		_, err = s.Store.Issue().Save(issue)
+		return err
 	}
 
-	hasChanges := false
-
-	if oldIssue.State != issue.State {
-		hasChanges = true
-	}
+	hasChanges := oldIssue.State != issue.State
 
 	for _, label := range issue.Labels {
 		hadLabel := false
@@ -59,30 +53,31 @@ func (s *Server) checkIssueForChanges(ctx context.Context, issue *model.Issue) {
 
 		if !hadLabel {
 			mlog.Info("issue added label", mlog.Int("issue", issue.Number), mlog.String("label", label))
-			s.handleIssueLabeled(ctx, issue, label)
+			err = s.handleIssueLabeled(ctx, issue, label)
+			if err != nil {
+				return fmt.Errorf("could not handle issue label added: %w", err)
+			}
 			hasChanges = true
 		}
 	}
 
 	if hasChanges {
 		mlog.Info("issue has changes", mlog.Int("issue", issue.Number))
-
-		if _, err := s.Store.Issue().Save(issue); err != nil {
-			mlog.Error(err.Error())
-			return
-		}
+		_, err = s.Store.Issue().Save(issue)
+		return err
 	}
+
+	return nil
 }
 
-func (s *Server) handleIssueLabeled(ctx context.Context, issue *model.Issue, addedLabel string) {
+func (s *Server) handleIssueLabeled(ctx context.Context, issue *model.Issue, addedLabel string) error {
 	// Must be sure the comment is created before we let anouther request test
 	s.commentLock.Lock()
 	defer s.commentLock.Unlock()
 
 	comments, _, err := s.GithubClient.Issues.ListComments(ctx, issue.RepoOwner, issue.RepoName, issue.Number, nil)
 	if err != nil {
-		mlog.Error("issue_error", mlog.Err(err))
-		return
+		return fmt.Errorf("could not get issue from GitHub: %w", err)
 	}
 
 	for _, label := range s.Config.IssueLabels {
@@ -92,4 +87,5 @@ func (s *Server) handleIssueLabeled(ctx context.Context, issue *model.Issue, add
 			s.sendGitHubComment(ctx, issue.RepoOwner, issue.RepoName, issue.Number, finalMessage)
 		}
 	}
+	return nil
 }

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -514,7 +514,7 @@ func (s *Server) isBlockPRMergeInLabels(labels []string) bool {
 
 func (s *Server) getPRFromEvent(ctx context.Context, event EventData) (*model.PullRequest, error) {
 	if event.Issue == nil || event.Repository == nil {
-		return nil, errors.New("either issue and repository field is missing to from the event data")
+		return nil, errors.New("either issue or repository field is missing from the event data")
 	}
 
 	prGitHub, _, err := s.GithubClient.PullRequests.Get(ctx,

--- a/server/server.go
+++ b/server/server.go
@@ -187,7 +187,9 @@ func (s *Server) Tick() {
 				continue
 			}
 
-			s.checkIssueForChanges(ctx, issue)
+			if err := s.checkIssueForChanges(ctx, issue); err != nil {
+				mlog.Error("could not check issue for changes", mlog.Err(err))
+			}
 		}
 	}
 }
@@ -239,7 +241,10 @@ func (s *Server) githubEvent(w http.ResponseWriter, r *http.Request) {
 
 	eventData := EventDataFromJSON(ioutil.NopCloser(bytes.NewBuffer(buf)))
 	if eventData == nil || eventData.Action != "created" {
-		s.handleIssueEvent(ctx, event)
+		err = s.handleIssueEvent(ctx, event)
+		if err != nil {
+			mlog.Error(err.Error())
+		}
 		return
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -241,8 +241,7 @@ func (s *Server) githubEvent(w http.ResponseWriter, r *http.Request) {
 
 	eventData := EventDataFromJSON(ioutil.NopCloser(bytes.NewBuffer(buf)))
 	if eventData == nil || eventData.Action != "created" {
-		err = s.handleIssueEvent(ctx, event)
-		if err != nil {
+		if err = s.handleIssueEvent(ctx, event); err != nil {
 			mlog.Error(err.Error())
 		}
 		return


### PR DESCRIPTION
#### Summary
Added error propagation to the issue event handler. The ticket was originally for a logical error in the `server.githubEvent`, but it is taken care in #168 so I added a small refactor around error handling instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26819

