### PR TITLE
[MM-26815] server/pull_request: tweak auto merge label handling

### DIFF
--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -86,7 +86,7 @@ func (s *Server) handlePullRequestEvent(ctx context.Context, event *PullRequestE
 				mlog.Error("Unable to create the github status for for PR", mlog.Int("pr", pr.Number), mlog.Err(err))
 			}
 		}
-		if s.hasAutoMerge(pr.Labels) {
+		if event.Label.GetName() == s.Config.AutoPRMergeLabel {
 			msg := "Will try to auto merge this PR once all tests and checks are passing. This might take up to an hour."
 			s.sendGitHubComment(ctx, pr.RepoOwner, pr.RepoName, pr.Number, msg)
 		}


### PR DESCRIPTION

#### Summary
This PR changes the way we check if the event has Auto Merge label. Currently we are checking every label for any `labeled` action. And it seems like we are receiving this event multiple times (actually, number of labels times). Thus, we send "Will try to auto merge..." message several times. This change will focus on the specific event for the actual Auto Merge label.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26815

