### PR TITLE
Containerize mattermod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,37 @@ jobs:
             echo Failed waiting for MySQL && exit 1
       - run: make test
 
+  docker:
+    parameters:
+      target:
+        type: string
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build docker image
+          command: |
+            if [ -z "<<parameters.target>>" ]; then
+              echo "'target' is missing"
+              exit 1
+            fi
+            if [ "<<parameters.target>>" == "pr" ]; then
+              export TAG_NAME=$(echo "${CIRCLE_SHA1}" | cut -c1-8)
+              DOCKER_TAG=${TAG_NAME} make docker
+            else
+              echo ${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin
+              if [ "<<parameters.target>>" == "edge" ]; then
+                DOCKER_TAG=edge make docker push
+              elif [ "<<parameters.target>>" == "latest" ]; then
+                export TAG_NAME=$(echo "${CIRCLE_TAG}" | tr -d 'v')
+                DOCKER_TAG=${TAG_NAME} make docker push
+                docker tag mattermost/mattermod:${TAG_NAME} mattermost/mattermod:latest
+                DOCKER_TAG=latest make push
+              fi
+            fi
+
 workflows:
   version: 2
   untagged-build:
@@ -72,3 +103,30 @@ workflows:
       - test:
           requires:
             - build
+      - docker:
+          name: docker-pr
+          target: pr
+          requires:
+            - test
+          filters:
+            branches:
+              ignore: master
+      - docker:
+          name: docker-edge
+          target: edge
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
+
+  release-build:
+    jobs:
+      - docker:
+          name: docker-latest
+          target: latest
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.14.2-alpine AS builder
+
+RUN apk add --update --no-cache ca-certificates bash make gcc musl-dev git openssh wget curl bzr
+
+WORKDIR /go/src/mattermod
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 make build
+
+################
+
+FROM alpine:3.12.0
+
+RUN apk --no-cache add ca-certificates
+
+COPY --from=builder /go/src/mattermod/dist/mattermod /usr/local/bin/
+
+WORKDIR /app
+
+RUN mkdir -p /app/logs && chown -R 1000:1000 /app/logs/
+
+USER 1000
+EXPOSE 8080
+
+ENTRYPOINT ["mattermod"]

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ PACKAGES=$(shell go list ./...)
 .PHONY: all
 all: check-style test
 
+## Cleans workspace
+.PHONY: clean
+clean:
+	rm -rf dist/ out/
+
 ## Checks code style.
 .PHONY: check-style
 check-style: golangci-lint
@@ -24,25 +29,32 @@ golangci-lint:
 	@echo Running golangci-lint
 	golangci-lint run ./...
 
-build:
-	@echo Building
-
-	rm -rf dist/
-	mkdir -p dist/mattermod
-	$(GO) build ./cmd/mattermost-mattermod
-	mv mattermost-mattermod dist/mattermod/
-	cp config/config-mattermod.default.json dist/mattermod/config-mattermod.json
-
-
-package: build
-	tar -C dist -czf dist/mattermod.tar.gz mattermod
-
 ## Runs tests.
 test:
 	@echo Running Go tests
 	$(GO) test $(PACKAGES)
 	@echo test success
 
+## Builds mattermod.
+.PHONY: build
+build: clean
+	@echo Building
+	$(GO) build -o dist/mattermod ./cmd/mattermost-mattermod
+
+# Docker variables
+DEFAULT_TAG  ?= $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
+DOCKER_IMAGE ?= mattermost/mattermod
+DOCKER_TAG   ?= $(shell echo "$(DEFAULT_TAG)" | tr -d 'v')
+
+## Build Docker image
+.PHONY: docker
+docker:
+	docker build --pull --tag $(DOCKER_IMAGE):$(DOCKER_TAG) --file Dockerfile .
+
+## Push Docker image
+.PHONY: push
+push:
+	docker push $(DOCKER_IMAGE):$(DOCKER_TAG)
 
 ## Generate mocks.
 .PHONY: mocks
@@ -61,4 +73,4 @@ mocks:
 
 # Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
-	@cat Makefile | grep -v '\.PHONY' |  grep -v '\help:' | grep -B1 -E '^[a-zA-Z_.-]+:.*' | sed -e "s/:.*//" | sed -e "s/^## //" |  grep -v '\-\-' | sed '1!G;h;$$!d' | awk 'NR%2{printf "\033[36m%-30s\033[0m",$$0;next;}1' | sort
+	@cat Makefile | grep -v '\.PHONY' |  grep -v '\help:' | grep -B1 -E '^[a-zA-Z_.-]+:.*' | sed -e "s/:.*//" | sed -e "s/^## //" |  grep -v '\-\-' | uniq | sed '1!G;h;$$!d' | awk 'NR%2{printf "\033[36m%-30s\033[0m",$$0;next;}1' | sort


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Containerizing `mattermod`. As a result two extra Makefile targets adde:

- `make docker`: to build the docker image
- `make push`: to push docker image to DockerHub

Example usage:

```bash
DOCKER_TAG=latest make docker push
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

