### PR TITLE
Replacing blacklist with blocklist where is possible without braking the API

### DIFF
--- a/server/circleci.go
+++ b/server/circleci.go
@@ -50,10 +50,10 @@ func (s *Server) triggerCircleCiIfNeeded(ctx context.Context, pr *model.PullRequ
 	}
 
 	for _, prFile := range prFiles {
-		for _, blackListPath := range s.Config.BlacklistPaths {
-			if prFile.GetFilename() == blackListPath {
-				mlog.Error("File is on the blacklist and will not retrigger circleci to give the contexts", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName))
-				msg := fmt.Sprintf("The file `%s` is in the blacklist and should not be modified from external contributors, please if you are part of the Mattermost Org submit this PR in the upstream.\n /cc @mattermost/core-security @mattermost/core-build-engineers", prFile.GetFilename())
+		for _, blockListPath := range s.Config.BlacklistPaths {
+			if prFile.GetFilename() == blockListPath {
+				mlog.Error("File is on the blocklist and will not retrigger circleci to give the contexts", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName))
+				msg := fmt.Sprintf("The file `%s` is in the blocklist and should not be modified from external contributors, please if you are part of the Mattermost Org submit this PR in the upstream.\n /cc @mattermost/core-security @mattermost/core-build-engineers", prFile.GetFilename())
 				s.sendGitHubComment(ctx, pr.RepoOwner, pr.RepoName, pr.Number, msg)
 				return
 			}


### PR DESCRIPTION
There is still a config setting for mattermod called "Blacklist" but I haven't changed it because that would break the API.