### PR TITLE
Fix placement of production config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ Session.vim
 # Deployment
 deploy/base/config/*
 !deploy/base/config/kustomization.yaml
+deploy/overlays/prod/config/
 out/

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -17,11 +17,11 @@ configMapGenerator:
   - name: config
     behavior: merge
     files:
-      - instance-setup-mattermost-server
-      - instance-setup-mattermost-webapp
-      - instance-setup-upgrade-mattermost-server
-      - test.spinmint.com.fullchain.pem
-      - test.spinmint.com.privkey.pem
+      - config/instance-setup-mattermost-server
+      - config/instance-setup-mattermost-webapp
+      - config/instance-setup-upgrade-mattermost-server
+      - config/test.spinmint.com.fullchain.pem
+      - config/test.spinmint.com.privkey.pem
 
 images:
   - name: mattermost/mattermod


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
For security reason we can only place config files in or under current kustomization folder, as such `deploy/overlays/prod/` cannot access gitignored config files under `deploy/config/`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

