### PR TITLE
Skip webhook SHA validation for /healthz

### DIFF
--- a/server/validate_signature.go
+++ b/server/validate_signature.go
@@ -16,6 +16,9 @@ import (
 
 func (s *Server) withValidation(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI == "/healthz" {
+			next.ServeHTTP(w, r)
+		}
 		receivedHash := strings.SplitN(r.Header.Get("X-Hub-Signature"), "=", 2)
 		if receivedHash[0] != "sha1" {
 			mlog.Error("Invalid webhook hash signature: SHA1")

--- a/server/validate_signature_test.go
+++ b/server/validate_signature_test.go
@@ -68,6 +68,16 @@ func TestWithValidationMiddleware(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		defer resp.Body.Close()
 	})
+
+	t.Run("Should skip validation", func(t *testing.T) {
+		req, err := http.NewRequest("GET", ts.URL+"/healthz", nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		defer resp.Body.Close()
+	})
 }
 
 func TestValidateSignatureWithIncorrectSignature(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
#184 added middleware validation which this PR skips that only for `/healthz` endpoint.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

