### PR TITLE
Properly log the full panic trace

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -164,7 +165,9 @@ func (s *Server) withRecovery(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if x := recover(); x != nil {
-				mlog.Error("recovered from a panic", mlog.String("url", r.URL.String()), mlog.Any("error", x))
+				mlog.Error("recovered from a panic",
+					mlog.String("url", r.URL.String()),
+					mlog.String("error", string(debug.Stack())))
 			}
 		}()
 		next.ServeHTTP(w, r)

--- a/server/server.go
+++ b/server/server.go
@@ -167,7 +167,8 @@ func (s *Server) withRecovery(next http.Handler) http.Handler {
 			if x := recover(); x != nil {
 				mlog.Error("recovered from a panic",
 					mlog.String("url", r.URL.String()),
-					mlog.String("error", string(debug.Stack())))
+					mlog.Any("error", x),
+					mlog.String("stack", string(debug.Stack())))
 			}
 		}()
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
Just the error only contains the title "Nil pointer dereference".
We log the full stack trace for full visibility.
