### PR TITLE
MM-27189: Fix comment with empty body

### DIFF
--- a/server/update_branch.go
+++ b/server/update_branch.go
@@ -63,5 +63,6 @@ func (s *Server) handleUpdateBranch(ctx context.Context, commenter string, pr *m
 		return err
 	}
 
-	return nil
+	err = nil
+	return err
 }

--- a/server/update_branch_test.go
+++ b/server/update_branch_test.go
@@ -130,4 +130,19 @@ func TestHandeUpdateBranch(t *testing.T) {
 		err := s.handleUpdateBranch(ctx, userHandle, pr)
 		require.NoError(t, err)
 	})
+
+	t.Run("job scheduled on GitHub", func(t *testing.T) {
+		s.OrgMembers = make([]string, 1)
+		s.OrgMembers[0] = userHandle
+		pr.FullName = organization + "/" + userHandle
+
+		*msg = ""
+
+		prs := mocks.NewMockPullRequestsService(ctrl)
+		prs.EXPECT().UpdateBranch(ctx, pr.RepoOwner, pr.RepoName, pr.Number, gomock.AssignableToTypeOf(opt)).Return(nil, nil, errors.New("job scheduled on GitHub side; try again later"))
+		s.GithubClient.PullRequests = prs
+
+		err := s.handleUpdateBranch(ctx, userHandle, pr)
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
The original code didn't comment when the error contained
"job scheduled on GitHub side; try again later"

```
if !strings.Contains("job scheduled on GitHub side; try again later", err.Error()) {
			msg := fmt.Sprintf("Error trying to update the PR.\nPlease do it manually.\nError: %s", err.Error())
			s.sendGitHubComment(ctx, pr.RepoOwner, pr.RepoName, pr.Number, msg)
		}
```

But we did not reset the err variable, which attempted to comment with an empty message.
We fix this by setting err to nil.
