### PR TITLE
server: fix gh issue service error if there isnt repo field in issue

### DIFF
--- a/server/issue_handler_test.go
+++ b/server/issue_handler_test.go
@@ -96,6 +96,24 @@ func TestIssueEventHandler(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
+	t.Run("Should fail incorrect url", func(t *testing.T) {
+		url := "http://someaddr.com"
+
+		b, err := json.Marshal(&PullRequestEvent{
+			Issue: &github.Issue{
+				HTMLURL: &url,
+			},
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("POST", ts.URL, bytes.NewReader(b))
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	})
+
 	t.Run("Should fail for not getting issue from github", func(t *testing.T) {
 		is.EXPECT().ListLabelsByIssue(gomock.AssignableToTypeOf(ctxInterface), issue.RepoOwner, issue.RepoName, issue.Number, nil).
 			Times(1).

--- a/server/issue_handler_test.go
+++ b/server/issue_handler_test.go
@@ -96,8 +96,30 @@ func TestIssueEventHandler(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
-	t.Run("Should fail incorrect url", func(t *testing.T) {
+	t.Run("Should fail for incorrect url", func(t *testing.T) {
 		url := "http://someaddr.com"
+
+		b, err := json.Marshal(&PullRequestEvent{
+			Issue: &github.Issue{
+				HTMLURL: &url,
+			},
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("POST", ts.URL, bytes.NewReader(b))
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	})
+
+	t.Run("Should be able to parse url", func(t *testing.T) {
+		url := "https://github.com/owner/repo/pull/1" //we are not parsing issue number
+
+		is.EXPECT().ListLabelsByIssue(gomock.AssignableToTypeOf(ctxInterface), "owner", "repo", 0, nil).
+			Times(1).
+			Return(nil, nil, errors.New("error"))
 
 		b, err := json.Marshal(&PullRequestEvent{
 			Issue: &github.Issue{


### PR DESCRIPTION
#### Summary
Yet another regression found during local testing for #186. In some cases GitHub does not adding Repository field for issues in webhook requests. In those cases, we try to parse the `htmlURL` to get repo name and repo owner.



