### PR TITLE
MM-27373: Ignore comments coming from issues

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -293,6 +293,11 @@ func (s *Server) githubEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// We ignore comments from issues.
+	if !eventData.Issue.IsPullRequest() {
+		return
+	}
+
 	pr, err := s.getPRFromEvent(ctx, *eventData)
 	if err != nil {
 		mlog.Error("Error getting PR from Comment", mlog.Err(err))


### PR DESCRIPTION
When parsing slash commands, all of them are from pull requests.
Therefore, we just ignore everything if it's not a pull request.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-27373