### PR TITLE
Expose /metrics endpoint to be scraped later on

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,6 @@ RUN for d in .ssh repos logs; do \
     done
 
 USER mattermod
-EXPOSE 8080
+EXPOSE 8080 9000
 
 ENTRYPOINT ["mattermod"]

--- a/Tiltfile
+++ b/Tiltfile
@@ -2,4 +2,4 @@ docker_build('mattermost/mattermod', '.', dockerfile='Dockerfile')
 
 k8s_yaml(kustomize('./deploy/overlays/dev'))
 
-k8s_resource('mattermod', port_forwards=8080)
+k8s_resource('mattermod', port_forwards=[8080, 9000])

--- a/config/config-mattermod.default.json
+++ b/config/config-mattermod.default.json
@@ -1,5 +1,5 @@
 {
-    "ListenAddress": "0.0.0.0:8086",
+    "ListenAddress": "0.0.0.0:8080",
     "MattermodURL": "",
     "GithubAccessToken": "",
     "GitHubTokenReserve": 10,

--- a/config/config-mattermod.default.json
+++ b/config/config-mattermod.default.json
@@ -120,7 +120,7 @@
     "MattermostWebhookURL": "",
     "MattermostWebhookFooter": "",
 
-    "MetricsServerPort": "8067",
+    "MetricsServerPort": "9000",
 
     "LogSettings": {
         "EnableConsole": true,

--- a/deploy/base/app/deployment.yaml
+++ b/deploy/base/app/deployment.yaml
@@ -16,6 +16,10 @@ spec:
   minReadySeconds: 5
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9000"
+        prometheus.io/scrape: "true"
       labels:
         app: mattermod
     spec:
@@ -41,6 +45,8 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+            - name: metrics
+              containerPort: 9000
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/base/app/service.yaml
+++ b/deploy/base/app/service.yaml
@@ -11,3 +11,6 @@ spec:
     - name: http
       port: 8080
       targetPort: http
+    - name: metrics
+      port: 9000
+      targetPort: metrics


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Exposing `/metrics` endpoint internally for Promethues to scrape them later on.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

