### PR TITLE
[MM-27431] Multiple metrics fixes

### DIFF
--- a/metrics/provider.go
+++ b/metrics/provider.go
@@ -123,6 +123,7 @@ func NewPrometheusProvider() *PrometheusProvider {
 		},
 		[]string{"method", "handler"},
 	)
+	provider.Registry.MustRegister(provider.githubCacheHits)
 
 	provider.githubCacheMisses = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -133,6 +134,7 @@ func NewPrometheusProvider() *PrometheusProvider {
 		},
 		[]string{"method", "handler"},
 	)
+	provider.Registry.MustRegister(provider.githubCacheMisses)
 
 	return provider
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -60,7 +60,10 @@ func (t *MetricsTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 	}
 	splittedPath := strings.Split(req.URL.Path, "/")
 	// This would leave path as "/repos/{user/org}/{repository}/issues"
-	path := strings.Join(splittedPath[:5], "/")
+	path := req.URL.Path
+	if len(splittedPath) > 5 {
+		path = strings.Join(splittedPath[:5], "/")
+	}
 	statusCode := strconv.Itoa(resp.StatusCode)
 	t.metrics.ObserveGithubRequestDuration(path, req.Method, statusCode, elapsed)
 

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -59,9 +59,9 @@ func (t *MetricsTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 		return resp, err
 	}
 	splittedPath := strings.Split(req.URL.Path, "/")
-	// This would leave path as "/repos/{user/org}/{repository}/issues"
 	path := req.URL.Path
 	if len(splittedPath) > 5 {
+		// This would leave path as "/repos/{user/org}/{repository}/issues"
 		path = strings.Join(splittedPath[:5], "/")
 	}
 	statusCode := strconv.Itoa(resp.StatusCode)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR includes some fixes to the metrics:

- Fixed the missing registration of the githubCache metrics
- Fixed the order of parameters in github metrics that was wrong and was sending the method to the handler and other way around
- Reduce the path string to avoid too much unnecessary information as you can see in the next screenshot:

![Screenshot from 2020-07-31 19-13-49](https://user-images.githubusercontent.com/741240/89059911-5ab09880-d362-11ea-8bc0-89030f4240b8.png)

  now we plan to store "/repo/{user|org}/{repository}/{api_endpoint}" where api_endpoint could be something like: issues, branches, etc

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-27431