### PR TITLE
use PR from event when checking if PR is mergeable

### DIFF
--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -56,14 +56,14 @@ func (s *Server) checkIfNeedCherryPick(pr *model.PullRequest) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout*time.Second)
 	defer cancel()
 
-	prCherryCandidate, _, err := s.GithubClient.PullRequests.Get(ctx, pr.RepoOwner, pr.RepoName, pr.Number)
-	if err != nil {
-		mlog.Error("Error getting the PR info", mlog.Err(err))
+	if !pr.Merged.Valid || !pr.Merged.Bool {
+		mlog.Info("PR not merged, not cherry picking", mlog.Int("PR Number", pr.Number), mlog.String("Repo", pr.RepoName))
 		return
 	}
 
-	if !prCherryCandidate.GetMerged() {
-		mlog.Info("PR not merged, not cherry picking", mlog.Int("PR Number", prCherryCandidate.GetNumber()), mlog.String("Repo", pr.RepoName))
+	prCherryCandidate, _, err := s.GithubClient.PullRequests.Get(ctx, pr.RepoOwner, pr.RepoName, pr.Number)
+	if err != nil {
+		mlog.Error("Error getting the PR info", mlog.Err(err))
 		return
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The production instance of mattermod seems to think that some merged and closed PRs have been closed but not merged. The closing of the PR triggers the event in mattermod, which then queries Github to check if the PR has been merged. The response from Github appears to be that the PR was not merged, although manually checking the API response from Github a little while later shows that the event has been merged. 

This leads me to suspect a caching issue. In this PR mattermod uses the merge state information from the event itself instead of querying Github again. According to the Github docs [1][2], the event contains all the information we need so we should not need to query Github again. 

[1] https://developer.github.com/webhooks/event-payloads/#pull_request 
[2] https://developer.github.com/v3/pulls/#get-a-pull-request

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- N/A, but I've made a follow-up issue to fix this issue across the code base: https://mattermost.atlassian.net/browse/MM-27487