### PR TITLE
MM-26455: Use pagination for long API calls

### DIFF
--- a/server/circleci.go
+++ b/server/circleci.go
@@ -59,7 +59,7 @@ func (s *Server) triggerCircleCiIfNeeded(ctx context.Context, pr *model.PullRequ
 	}
 
 	// List the files that was modified or added in the PullRequest
-	prFiles, _, err := s.GithubClient.PullRequests.ListFiles(ctx, pr.RepoOwner, pr.RepoName, pr.Number, nil)
+	prFiles, err := s.getFiles(ctx, pr.RepoOwner, pr.RepoName, pr.Number)
 	if err != nil {
 		mlog.Error("Error listing the files from a PR", mlog.String("repo", pr.RepoName), mlog.Int("pr", pr.Number), mlog.String("Fullname", pr.FullName), mlog.Err(err))
 		return

--- a/server/cla.go
+++ b/server/cla.go
@@ -30,7 +30,7 @@ func (s *Server) handleCheckCLA(ctx context.Context, pr *model.PullRequest) erro
 		mlog.String("user", username),
 		mlog.String("repo", pr.RepoOwner),
 		mlog.String("reponame", pr.RepoName),
-		mlog.Int("pr n", pr.Number),
+		mlog.Int("pr number", pr.Number),
 	)
 
 	if s.IsBotUserFromCLAExclusionsList(username) {
@@ -50,7 +50,7 @@ func (s *Server) handleCheckCLA(ctx context.Context, pr *model.PullRequest) erro
 	}
 
 	if !isNameInCLAList(strings.Split(string(body), "\n"), username) {
-		comments, err := s.getComments(ctx, pr)
+		comments, err := s.getComments(ctx, pr.RepoOwner, pr.RepoName, pr.Number)
 		if err != nil {
 			return fmt.Errorf("failed fetching comments: %w", err)
 		}

--- a/server/github.go
+++ b/server/github.go
@@ -143,7 +143,7 @@ func (s *Server) removeLabel(ctx context.Context, repoOwner, repoName string, nu
 	mlog.Info("Finished removing the label")
 }
 
-func (s *Server) getComments(ctx context.Context, repoOwner, repoName string, number int) ([]*github.IssueComment, error) {
+func (s *Server) getComments(ctx context.Context, repoOwner, repoName string, issueNumber int) ([]*github.IssueComment, error) {
 	opts := &github.IssueListCommentsOptions{
 		ListOptions: github.ListOptions{
 			PerPage: 100,
@@ -151,7 +151,7 @@ func (s *Server) getComments(ctx context.Context, repoOwner, repoName string, nu
 	}
 	var allComments []*github.IssueComment
 	for {
-		commentsPerPage, r, err := s.GithubClient.Issues.ListComments(ctx, repoOwner, repoName, number, opts)
+		commentsPerPage, r, err := s.GithubClient.Issues.ListComments(ctx, repoOwner, repoName, issueNumber, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -167,14 +167,14 @@ func (s *Server) getComments(ctx context.Context, repoOwner, repoName string, nu
 	return allComments, nil
 }
 
-func (s *Server) getFiles(ctx context.Context, repoOwner, repoName string, number int) ([]*github.CommitFile, error) {
+func (s *Server) getFiles(ctx context.Context, repoOwner, repoName string, issueNumber int) ([]*github.CommitFile, error) {
 	opts := &github.ListOptions{
 		PerPage: 100,
 	}
 	var allFiles []*github.CommitFile
 
 	for {
-		files, r, err := s.GithubClient.PullRequests.ListFiles(ctx, repoOwner, repoName, number, opts)
+		files, r, err := s.GithubClient.PullRequests.ListFiles(ctx, repoOwner, repoName, issueNumber, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/server/issue_handler.go
+++ b/server/issue_handler.go
@@ -100,7 +100,7 @@ func (s *Server) handleIssueLabeled(ctx context.Context, issue *model.Issue, add
 	s.commentLock.Lock()
 	defer s.commentLock.Unlock()
 
-	comments, _, err := s.GithubClient.Issues.ListComments(ctx, issue.RepoOwner, issue.RepoName, issue.Number, nil)
+	comments, err := s.getComments(ctx, issue.RepoOwner, issue.RepoName, issue.Number)
 	if err != nil {
 		return fmt.Errorf("could not get issue from GitHub: %w", err)
 	}

--- a/server/issue_handler_test.go
+++ b/server/issue_handler_test.go
@@ -215,7 +215,7 @@ func TestIssueEventHandler(t *testing.T) {
 				},
 			}, nil, nil)
 
-		is.EXPECT().ListComments(gomock.AssignableToTypeOf(ctxInterface), issue.RepoOwner, issue.RepoName, issue.Number, nil).
+		is.EXPECT().ListComments(gomock.AssignableToTypeOf(ctxInterface), issue.RepoOwner, issue.RepoName, issue.Number, gomock.AssignableToTypeOf(&github.IssueListCommentsOptions{})).
 			Times(1).Return(
 			[]*github.IssueComment{
 				{
@@ -224,7 +224,9 @@ func TestIssueEventHandler(t *testing.T) {
 						Login: &login,
 					},
 				},
-			}, nil, nil)
+			}, &github.Response{
+				NextPage: 0,
+				Response: &http.Response{StatusCode: http.StatusOK}}, nil)
 
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), issue.RepoOwner, issue.RepoName, issue.Number, &github.IssueComment{Body: &body}).
 			Times(1).Return(nil, nil, nil)

--- a/server/pagination_test.go
+++ b/server/pagination_test.go
@@ -1,0 +1,230 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/mattermost/mattermost-mattermod/server/mocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-github/v32/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetComments(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
+
+	issueMocks := mocks.NewMockIssuesService(ctrl)
+	mockedClient := &GithubClient{
+		Issues: issueMocks,
+	}
+
+	t.Run("One page", func(t *testing.T) {
+		comments := []*github.IssueComment{
+			{ID: github.Int64(1), NodeID: github.String("nodeid")},
+			{ID: github.Int64(2), NodeID: github.String("nodeid2")},
+		}
+
+		s := &Server{
+			Config: &Config{
+				Org: "mattertest",
+			},
+			GithubClient: mockedClient,
+		}
+
+		issueMocks.EXPECT().
+			ListComments(gomock.AssignableToTypeOf(ctxInterface),
+				gomock.Eq("mattertest"),
+				gomock.Eq("mattermost-server"),
+				gomock.Eq(1234),
+				gomock.AssignableToTypeOf(&github.IssueListCommentsOptions{}),
+			).
+			Return(comments, &github.Response{
+				NextPage: 0,
+				Response: &http.Response{StatusCode: http.StatusOK}},
+				nil)
+
+		got, err := s.getComments(context.Background(), "mattertest", "mattermost-server", 1234)
+		require.NoError(t, err)
+		assert.Equal(t, comments, got)
+	})
+
+	t.Run("Two pages", func(t *testing.T) {
+		comments := []*github.IssueComment{
+			{ID: github.Int64(1), NodeID: github.String("nodeid")},
+		}
+
+		comments2 := []*github.IssueComment{
+			{ID: github.Int64(2), NodeID: github.String("nodeid2")},
+		}
+
+		s := &Server{
+			Config: &Config{
+				Org: "mattertest",
+			},
+			GithubClient: mockedClient,
+		}
+
+		firstCall := issueMocks.EXPECT().
+			ListComments(gomock.AssignableToTypeOf(ctxInterface),
+				gomock.Eq("mattertest"),
+				gomock.Eq("mattermost-server"),
+				gomock.Eq(1234),
+				gomock.AssignableToTypeOf(&github.IssueListCommentsOptions{}),
+			).
+			Return(comments, &github.Response{
+				NextPage: 2,
+				Response: &http.Response{StatusCode: http.StatusOK}},
+				nil)
+		issueMocks.EXPECT().
+			ListComments(gomock.AssignableToTypeOf(ctxInterface),
+				gomock.Eq("mattertest"),
+				gomock.Eq("mattermost-server"),
+				gomock.Eq(1234),
+				gomock.AssignableToTypeOf(&github.IssueListCommentsOptions{}),
+			).
+			Return(comments2, &github.Response{
+				NextPage: 0,
+				Response: &http.Response{StatusCode: http.StatusOK}},
+				nil).After(firstCall)
+
+		got, err := s.getComments(context.Background(), "mattertest", "mattermost-server", 1234)
+		require.NoError(t, err)
+		assert.Equal(t, append(comments, comments2...), got)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		comments := []*github.IssueComment{}
+
+		s := &Server{
+			Config: &Config{
+				Org: "mattertest",
+			},
+			GithubClient: mockedClient,
+		}
+
+		issueMocks.EXPECT().
+			ListComments(gomock.AssignableToTypeOf(ctxInterface),
+				gomock.Eq("mattertest"),
+				gomock.Eq("mattermost-server"),
+				gomock.Eq(1234),
+				gomock.AssignableToTypeOf(&github.IssueListCommentsOptions{}),
+			).
+			Return(comments, &github.Response{}, errors.New("some error")).Times(1)
+
+		_, err := s.getComments(context.Background(), "mattertest", "mattermost-server", 1234)
+		require.Error(t, err)
+	})
+}
+
+func TestGetFiles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
+
+	prMocks := mocks.NewMockPullRequestsService(ctrl)
+	mockedClient := &GithubClient{
+		PullRequests: prMocks,
+	}
+
+	t.Run("One page", func(t *testing.T) {
+		files := []*github.CommitFile{
+			{SHA: github.String("sha1"), Filename: github.String("file1")},
+			{SHA: github.String("sha2"), Filename: github.String("file2")},
+		}
+
+		s := &Server{
+			Config: &Config{
+				Org: "mattertest",
+			},
+			GithubClient: mockedClient,
+		}
+
+		prMocks.EXPECT().
+			ListFiles(gomock.AssignableToTypeOf(ctxInterface),
+				gomock.Eq("mattertest"),
+				gomock.Eq("mattermost-server"),
+				gomock.Eq(1234),
+				gomock.AssignableToTypeOf(&github.ListOptions{}),
+			).
+			Return(files, &github.Response{
+				NextPage: 0,
+				Response: &http.Response{StatusCode: http.StatusOK}},
+				nil)
+
+		got, err := s.getFiles(context.Background(), "mattertest", "mattermost-server", 1234)
+		require.NoError(t, err)
+		assert.Equal(t, files, got)
+	})
+
+	t.Run("Two pages", func(t *testing.T) {
+		files := []*github.CommitFile{
+			{SHA: github.String("sha1"), Filename: github.String("file1")},
+		}
+
+		files2 := []*github.CommitFile{
+			{SHA: github.String("sha2"), Filename: github.String("file2")},
+		}
+
+		s := &Server{
+			Config: &Config{
+				Org: "mattertest",
+			},
+			GithubClient: mockedClient,
+		}
+
+		firstCall := prMocks.EXPECT().
+			ListFiles(gomock.AssignableToTypeOf(ctxInterface),
+				gomock.Eq("mattertest"),
+				gomock.Eq("mattermost-server"),
+				gomock.Eq(1234),
+				gomock.AssignableToTypeOf(&github.ListOptions{}),
+			).
+			Return(files, &github.Response{
+				NextPage: 2,
+				Response: &http.Response{StatusCode: http.StatusOK}},
+				nil)
+		prMocks.EXPECT().
+			ListFiles(gomock.AssignableToTypeOf(ctxInterface),
+				gomock.Eq("mattertest"),
+				gomock.Eq("mattermost-server"),
+				gomock.Eq(1234),
+				gomock.AssignableToTypeOf(&github.ListOptions{}),
+			).
+			Return(files2, &github.Response{
+				NextPage: 0,
+				Response: &http.Response{StatusCode: http.StatusOK}},
+				nil).After(firstCall)
+
+		got, err := s.getFiles(context.Background(), "mattertest", "mattermost-server", 1234)
+		require.NoError(t, err)
+		assert.Equal(t, append(files, files2...), got)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		files := []*github.CommitFile{}
+
+		s := &Server{
+			Config: &Config{
+				Org: "mattertest",
+			},
+			GithubClient: mockedClient,
+		}
+
+		prMocks.EXPECT().
+			ListFiles(gomock.AssignableToTypeOf(ctxInterface),
+				gomock.Eq("mattertest"),
+				gomock.Eq("mattermost-server"),
+				gomock.Eq(1234),
+				gomock.AssignableToTypeOf(&github.ListOptions{}),
+			).
+			Return(files, &github.Response{}, errors.New("some error")).Times(1)
+
+		_, err := s.getFiles(context.Background(), "mattertest", "mattermost-server", 1234)
+		require.Error(t, err)
+	})
+}

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -261,7 +261,7 @@ func (s *Server) handlePRLabeled(ctx context.Context, pr *model.PullRequest, add
 	s.commentLock.Lock()
 	defer s.commentLock.Unlock()
 
-	comments, _, err := s.GithubClient.Issues.ListComments(ctx, pr.RepoOwner, pr.RepoName, pr.Number, nil)
+	comments, err := s.getComments(ctx, pr.RepoOwner, pr.RepoName, pr.Number)
 	if err != nil {
 		mlog.Error("Unable to list comments for PR", mlog.Int("pr", pr.Number), mlog.Err(err))
 		return
@@ -301,7 +301,7 @@ func (s *Server) handlePRUnlabeled(ctx context.Context, pr *model.PullRequest, r
 	s.commentLock.Lock()
 	defer s.commentLock.Unlock()
 
-	comments, err := s.getComments(ctx, pr)
+	comments, err := s.getComments(ctx, pr.RepoOwner, pr.RepoName, pr.Number)
 	if err != nil {
 		mlog.Error("failed fetching comments", mlog.Err(err))
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -205,50 +205,67 @@ func (s *Server) Tick() {
 	}()
 
 	for _, repository := range s.Config.Repositories {
-		ghPullRequests, _, err := s.GithubClient.PullRequests.List(ctx, repository.Owner, repository.Name, &github.PullRequestListOptions{
-			State: "open",
-		})
-		if err != nil {
-			mlog.Error("Failed to get PRs", mlog.Err(err), mlog.String("repo_owner", repository.Owner), mlog.String("repo_name", repository.Name))
-			s.Metrics.IncreaseCronTaskErrors("tick")
-			continue
+		prListOpts := &github.PullRequestListOptions{
+			State:       "open",
+			ListOptions: github.ListOptions{PerPage: 50},
 		}
-
-		for _, ghPullRequest := range ghPullRequests {
-			pullRequest, errPR := s.GetPullRequestFromGithub(ctx, ghPullRequest)
-			if errPR != nil {
-				mlog.Error("failed to convert PR", mlog.Int("pr", *ghPullRequest.Number), mlog.Err(errPR))
-				s.Metrics.IncreaseCronTaskErrors("tick")
-				continue
-			}
-
-			s.checkPullRequestForChanges(ctx, pullRequest)
-		}
-
-		issues, _, err := s.GithubClient.Issues.ListByRepo(ctx, repository.Owner, repository.Name, &github.IssueListByRepoOptions{
-			State: "open",
-		})
-		if err != nil {
-			mlog.Error("Failed to get issues", mlog.Err(err), mlog.String("repo_owner", repository.Owner), mlog.String("repo_name", repository.Name))
-			s.Metrics.IncreaseCronTaskErrors("tick")
-			continue
-		}
-
-		for _, ghIssue := range issues {
-			if ghIssue.PullRequestLinks != nil {
-				// This is a PR so we've already checked it
-				continue
-			}
-
-			issue, err := s.GetIssueFromGithub(ctx, ghIssue)
+		for {
+			ghPullRequests, resp, err := s.GithubClient.PullRequests.List(ctx, repository.Owner, repository.Name, prListOpts)
 			if err != nil {
-				mlog.Error("failed to convert issue", mlog.Int("issue", *ghIssue.Number), mlog.Err(err))
+				mlog.Error("Failed to get PRs", mlog.Err(err), mlog.String("repo_owner", repository.Owner), mlog.String("repo_name", repository.Name))
 				s.Metrics.IncreaseCronTaskErrors("tick")
 				continue
 			}
+			if resp.NextPage == 0 {
+				break
+			}
+			prListOpts.Page = resp.NextPage
 
-			if err := s.checkIssueForChanges(ctx, issue); err != nil {
-				mlog.Error("could not check issue for changes", mlog.Err(err))
+			for _, ghPullRequest := range ghPullRequests {
+				pullRequest, errPR := s.GetPullRequestFromGithub(ctx, ghPullRequest)
+				if errPR != nil {
+					mlog.Error("failed to convert PR", mlog.Int("pr", *ghPullRequest.Number), mlog.Err(errPR))
+					s.Metrics.IncreaseCronTaskErrors("tick")
+					continue
+				}
+
+				s.checkPullRequestForChanges(ctx, pullRequest)
+			}
+		}
+
+		issueListOpts := &github.IssueListByRepoOptions{
+			State:       "open",
+			ListOptions: github.ListOptions{PerPage: 50},
+		}
+
+		for {
+			issues, resp, err := s.GithubClient.Issues.ListByRepo(ctx, repository.Owner, repository.Name, issueListOpts)
+			if err != nil {
+				mlog.Error("Failed to get issues", mlog.Err(err), mlog.String("repo_owner", repository.Owner), mlog.String("repo_name", repository.Name))
+				s.Metrics.IncreaseCronTaskErrors("tick")
+				continue
+			}
+			if resp.NextPage == 0 {
+				break
+			}
+			issueListOpts.Page = resp.NextPage
+
+			for _, ghIssue := range issues {
+				if ghIssue.PullRequestLinks != nil {
+					// This is a PR so we've already checked it
+					continue
+				}
+
+				issue, err := s.GetIssueFromGithub(ctx, ghIssue)
+				if err != nil {
+					mlog.Error("failed to convert issue", mlog.Int("issue", *ghIssue.Number), mlog.Err(err))
+					s.Metrics.IncreaseCronTaskErrors("tick")
+					continue
+				}
+
+				if err := s.checkIssueForChanges(ctx, issue); err != nil {
+					mlog.Error("could not check issue for changes", mlog.Err(err))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We use pagination for all API calls which are liable to return
more than 30 items.

https://mattermost.atlassian.net/browse/MM-26455