### PR TITLE
server/cherrypick: suppress linter error

### DIFF
--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -176,7 +176,7 @@ func (s *Server) getAssignee(ctx context.Context, newPRNumber int, pr *model.Pul
 			return ""
 		}
 
-		randomReviewer := rand.Intn(len(reviewersFromPR) - 1)
+		randomReviewer := rand.Intn(len(reviewersFromPR) - 1) // nolint
 		assignee = reviewersFromPR[randomReviewer].User.GetLogin()
 	}
 


### PR DESCRIPTION

#### Summary
This check just blindly looks for `math/rand` usage. At this point we don't need to check this. 

