### PR TITLE
[MM-27706] server/issue_comments: ignore deleted comments

### DIFF
--- a/server/issue_comment_handler.go
+++ b/server/issue_comment_handler.go
@@ -40,6 +40,11 @@ func (s *Server) issueCommentEventHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// We ignore deletion events for now.
+	if ev.Action == "deleted" {
+		return
+	}
+
 	pr, err := s.getPRFromIssueCommentEvent(ctx, ev)
 	if err != nil {
 		mlog.Error("Error getting PR from Comment", mlog.Err(err))

--- a/server/issue_comment_handler_test.go
+++ b/server/issue_comment_handler_test.go
@@ -117,6 +117,23 @@ func TestIssueCommentEventHandler(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
+	t.Run("Deletion event, should not fail", func(t *testing.T) {
+		b, err := json.Marshal(issueCommentEvent{
+			Action:     "deleted",
+			Issue:      &github.Issue{},
+			Repository: &github.Repository{},
+			Comment:    &github.PullRequestComment{},
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("POST", ts.URL, bytes.NewReader(b))
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
 	t.Run("Should fail on getting the PR", func(t *testing.T) {
 		prs.EXPECT().Get(gomock.AssignableToTypeOf(ctxInterface), event.Repository.GetOwner().GetLogin(), event.Repository.GetName(), event.Issue.GetNumber()).
 			Times(1).


### PR DESCRIPTION

#### Summary
This PR adds prevention of triggering commands again when they are deleted.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27706

