### PR TITLE
Add logs and increase default cron task timeouts

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -18,7 +18,7 @@ const (
 	// In seconds
 	defaultRequestTimeout       = 60
 	defaultEETaskTimeout        = 300
-	defaultCronTaskTimeout      = 300
+	defaultCronTaskTimeout      = 600
 	defaultBuildMobileTimeout   = 7200
 	defaultBuildSpinmintTimeout = 2700
 )

--- a/server/enterprise.go
+++ b/server/enterprise.go
@@ -26,7 +26,7 @@ func (s *Server) triggerEnterpriseTests(pr *model.PullRequest) {
 
 	triggerInfo, err := s.getPRInfo(ctx, pr)
 	if err != nil {
-		mlog.Debug("error trying to get pr info", mlog.Err(err))
+		mlog.Warn("error trying to get pr info", mlog.Err(err))
 		s.createEnterpriseTestsErrorStatus(ctx, pr, err)
 		return
 	}

--- a/server/enterprise.go
+++ b/server/enterprise.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -25,6 +26,7 @@ func (s *Server) triggerEnterpriseTests(pr *model.PullRequest) {
 
 	triggerInfo, err := s.getPRInfo(ctx, pr)
 	if err != nil {
+		mlog.Debug("error trying to get pr info", mlog.Err(err))
 		s.createEnterpriseTestsErrorStatus(ctx, pr, err)
 		return
 	}
@@ -59,12 +61,8 @@ type EETriggerInfo struct {
 func (s *Server) getPRInfo(ctx context.Context, pr *model.PullRequest) (info *EETriggerInfo, err error) {
 	pullRequest, _, err := s.GithubClient.PullRequests.Get(ctx, s.Config.Org, pr.RepoName, pr.Number)
 	if err != nil {
-		mlog.Debug("Error trying to get pr",
-			mlog.String("org", s.Config.Org),
-			mlog.String("repo", pr.RepoName),
-			mlog.Int("number", pr.Number),
-			mlog.Err(err))
-		return nil, err
+		return nil, fmt.Errorf("error trying to get pr number %d for repo %s: %w",
+			pr.Number, pr.RepoName, err)
 	}
 	baseBranch := pullRequest.GetBase().GetRef()
 	isFork := pullRequest.GetHead().GetRepo().GetFork()
@@ -110,12 +108,8 @@ func (s *Server) getBranchWithSameName(ctx context.Context, remote string, repo 
 	ghBranch, r, err := s.GithubClient.Repositories.GetBranch(ctx, remote, repo, ref)
 	if err != nil {
 		if r == nil || r.StatusCode != http.StatusNotFound {
-			mlog.Debug("Error trying to get branch",
-				mlog.String("remote", remote),
-				mlog.String("repo", repo),
-				mlog.String("ref", ref),
-				mlog.Err(err))
-			return "", err
+			return "", fmt.Errorf("error trying to get branch %s for repo %s: %w",
+				ref, repo, err)
 		}
 		return "", nil // do not err if branch is not found
 	}

--- a/server/enterprise.go
+++ b/server/enterprise.go
@@ -59,6 +59,11 @@ type EETriggerInfo struct {
 func (s *Server) getPRInfo(ctx context.Context, pr *model.PullRequest) (info *EETriggerInfo, err error) {
 	pullRequest, _, err := s.GithubClient.PullRequests.Get(ctx, s.Config.Org, pr.RepoName, pr.Number)
 	if err != nil {
+		mlog.Debug("Error trying to get pr",
+			mlog.String("org", s.Config.Org),
+			mlog.String("repo", pr.RepoName),
+			mlog.Int("number", pr.Number),
+			mlog.Err(err))
 		return nil, err
 	}
 	baseBranch := pullRequest.GetBase().GetRef()
@@ -105,6 +110,11 @@ func (s *Server) getBranchWithSameName(ctx context.Context, remote string, repo 
 	ghBranch, r, err := s.GithubClient.Repositories.GetBranch(ctx, remote, repo, ref)
 	if err != nil {
 		if r == nil || r.StatusCode != http.StatusNotFound {
+			mlog.Debug("Error trying to get branch",
+				mlog.String("remote", remote),
+				mlog.String("repo", repo),
+				mlog.String("ref", ref),
+				mlog.Err(err))
 			return "", err
 		}
 		return "", nil // do not err if branch is not found


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR adds two things:

- Debug logs for GH requests
- Increase the default timeout for cron tasks. Looks like we're getting timeouts since we added the pagination to get all the results

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

