### PR TITLE
Tweak CleanOutdatedPRs

### DIFF
--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -489,7 +489,7 @@ func (s *Server) CleanOutdatedPRs() {
 			mlog.Info("Nothing to do", mlog.String("RepoOwner", pr.RepoOwner), mlog.String("RepoName", pr.RepoName), mlog.Int("PRNumber", pr.Number))
 		}
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(200 * time.Millisecond)
 	}
 	mlog.Info("Finished update the outdated prs in the mattermod database....")
 }


### PR DESCRIPTION
After incorporating pagination, now we have a lot of PRs in the DB.
Logs show that at the start of a run, there are 339 PRs, and by the time
the 10 minute timeout is over, there are around 200 PRs which get cancelled.

This is primarily due to the fact that there is a 5 second sleep in between.
Which allows only 12 PRs in a minute, and therefore 120 PRs in 10 minutes.
Clearly that's not enough to process 339 PRs.

To fix this, we reduce the sleep time to 200 ms to allow for 5 requests/sec,
which is well-under the burst limit of 10/sec. This will allow for 300 PRs per minute
which should now be finishable under 10 minutes.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

