### PR TITLE
Clone git repos if they are not present locally

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,3 +50,5 @@ issues:
     # github.com/go-gorp/gorp.TypeConverter isn't golint compliant
     - "ST1003: method ToDb should be ToDB"
     - "ST1003: method FromDb should be FromD"
+    # For executing git commands.
+    - "G204: Subprocess launched with function call as argument or cmd arguments"

--- a/config/config-mattermod.default.json
+++ b/config/config-mattermod.default.json
@@ -4,6 +4,7 @@
     "GithubAccessToken": "",
     "GitHubTokenReserve": 10,
     "GithubUsername": "",
+    "GithubEmail": "",
     "GithubAccessTokenCherryPick": "",
     "GithubWebhookSecret": "",
     "Org": "",

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -341,24 +341,20 @@ func cloneRepo(ctx context.Context, dir, upstreamSlug, originSlug, repoName stri
 	cmd := exec.CommandContext(ctx, "git", "config", "user.name")
 	if out, err := runCommandWithOutput(cmd, dir); err != nil {
 		return err
-	} else {
-		if out == "" { // this means username is not set
-			cmd = exec.CommandContext(ctx, "git", "config", "--global", "user.name", "mattermost-build")
-			if err = runCommand(cmd, dir); err != nil {
-				return err
-			}
+	} else if out == "" { // this means username is not set
+		cmd = exec.CommandContext(ctx, "git", "config", "--global", "user.name", "mattermost-build")
+		if err = runCommand(cmd, dir); err != nil {
+			return err
 		}
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "config", "user.email")
 	if out, err := runCommandWithOutput(cmd, dir); err != nil {
 		return err
-	} else {
-		if out == "" { // this means email is not set
-			cmd = exec.CommandContext(ctx, "git", "config", "--global", "user.email", "build@mattermost.com")
-			if err = runCommand(cmd, dir); err != nil {
-				return err
-			}
+	} else if out == "" { // this means email is not set
+		cmd = exec.CommandContext(ctx, "git", "config", "--global", "user.email", "build@mattermost.com")
+		if err = runCommand(cmd, dir); err != nil {
+			return err
 		}
 	}
 

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -211,7 +211,6 @@ func (s *Server) doCherryPick(ctx context.Context, version string, milestoneNumb
 	cmd.Env = append(
 		os.Environ(),
 		os.Getenv("PATH"),
-		fmt.Sprintf("DRY_RUN=%t", false),
 		fmt.Sprintf("ORIGINAL_AUTHOR=%s", pr.Username),
 		fmt.Sprintf("GITHUB_USER=%s", s.Config.GithubUsername),
 		fmt.Sprintf("GITHUB_TOKEN=%s", s.Config.GithubAccessTokenCherryPick),

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -185,8 +185,8 @@ func (s *Server) doCherryPick(ctx context.Context, version string, milestoneNumb
 	}
 	repoFolder := filepath.Join(s.Config.RepoFolder, pr.RepoName)
 
-	if _, err := os.Stat(repoFolder); os.IsNotExist(err) {
-		err := cloneRepo(s.Config.RepoFolder, s.Config.Org+"/"+pr.RepoName, s.Config.GithubUsername+"/"+pr.RepoName, pr.RepoName)
+	if _, err = os.Stat(repoFolder); os.IsNotExist(err) {
+		err = cloneRepo(s.Config.RepoFolder, s.Config.Org+"/"+pr.RepoName, s.Config.GithubUsername+"/"+pr.RepoName, pr.RepoName)
 		if err != nil {
 			return "", fmt.Errorf("error while cloning repo: %s, %v", s.Config.Org+"/"+pr.RepoName, err)
 		}

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -338,13 +338,13 @@ func returnToMaster(ctx context.Context, dir string) error {
 
 func cloneRepo(ctx context.Context, dir, upstreamSlug, originSlug, repoName string) error {
 	// Clone repo
-	cmd = exec.CommandContext(ctx, "git", "clone", "--depth=1", "git@github.com:"+originSlug+".git")
+	cmd := exec.CommandContext(ctx, "git", "clone", "--depth=1", "git@github.com:"+originSlug+".git")
 	if err := runCommand(cmd, dir); err != nil {
 		return err
 	}
 
 	// Set username and email.
-	cmd := exec.CommandContext(ctx, "git", "config", "user.name")
+	cmd = exec.CommandContext(ctx, "git", "config", "user.name")
 	if out, err := runCommandWithOutput(cmd, filepath.Join(dir, repoName)); err != nil {
 		return err
 	} else if out == "" { // this means username is not set

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -337,31 +337,31 @@ func returnToMaster(ctx context.Context, dir string) error {
 }
 
 func cloneRepo(ctx context.Context, dir, upstreamSlug, originSlug, repoName string) error {
-	// Set username and email first.
+	// Clone repo
+	cmd = exec.CommandContext(ctx, "git", "clone", "--depth=1", "git@github.com:"+originSlug+".git")
+	if err := runCommand(cmd, dir); err != nil {
+		return err
+	}
+
+	// Set username and email.
 	cmd := exec.CommandContext(ctx, "git", "config", "user.name")
-	if out, err := runCommandWithOutput(cmd, dir); err != nil {
+	if out, err := runCommandWithOutput(cmd, filepath.Join(dir, repoName)); err != nil {
 		return err
 	} else if out == "" { // this means username is not set
-		cmd = exec.CommandContext(ctx, "git", "config", "--global", "user.name", "mattermost-build")
-		if err = runCommand(cmd, dir); err != nil {
+		cmd = exec.CommandContext(ctx, "git", "config", "user.name", "mattermost-build")
+		if err = runCommand(cmd, filepath.Join(dir, repoName)); err != nil {
 			return err
 		}
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "config", "user.email")
-	if out, err := runCommandWithOutput(cmd, dir); err != nil {
+	if out, err := runCommandWithOutput(cmd, filepath.Join(dir, repoName)); err != nil {
 		return err
 	} else if out == "" { // this means email is not set
-		cmd = exec.CommandContext(ctx, "git", "config", "--global", "user.email", "build@mattermost.com")
-		if err = runCommand(cmd, dir); err != nil {
+		cmd = exec.CommandContext(ctx, "git", "config", "user.email", "build@mattermost.com")
+		if err = runCommand(cmd, filepath.Join(dir, repoName)); err != nil {
 			return err
 		}
-	}
-
-	// Clone repo
-	cmd = exec.CommandContext(ctx, "git", "clone", "--depth=1", "git@github.com:"+originSlug+".git")
-	if err := runCommand(cmd, dir); err != nil {
-		return err
 	}
 
 	// Set upstream

--- a/server/config.go
+++ b/server/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	GithubAccessToken           string
 	GitHubTokenReserve          int
 	GithubUsername              string
+	GithubEmail                 string
 	GithubAccessTokenCherryPick string
 	GitHubWebhookSecret         string
 	Org                         string


### PR DESCRIPTION
- If the repo folder is not present locally, we clone it
and then set the upstream remote.
- While here, we also return error from returnToMaster function.
- And also, use CombinedOutput instead of Output which contains
output from standard error also. This can be helpful to debug errors.

https://mattermost.atlassian.net/browse/MM-27264
