### PR TITLE
MM-27539: Use pagination for s.waitForWorkflowID

### DIFF
--- a/server/circleci.go
+++ b/server/circleci.go
@@ -203,15 +203,33 @@ func (s *Server) waitForWorkflowID(ctx context.Context, id string, workflowName 
 		case <-ctx.Done():
 			return "", errors.New("timed out trying to fetch workflow")
 		case <-ticker.C:
-			wfList, err := s.CircleCiClientV2.GetPipelineWorkflowWithContext(ctx, id, "")
-			if err != nil {
-				return "", err
-			}
-
+			token := ""
 			workflowID := ""
-			for _, wf := range wfList.Items {
-				if wf.Name == workflowName {
-					workflowID = wf.ID
+			for {
+				wfList, err := s.CircleCiClientV2.GetPipelineWorkflowWithContext(ctx, id, token)
+				if err != nil {
+					var apiError *circleci.APIError
+					if errors.As(err, &apiError) && apiError.HTTPStatusCode >= 400 && apiError.HTTPStatusCode < 500 {
+						// We retry if it's a client side issue
+						continue
+					}
+					return "", err
+				}
+
+				for _, wf := range wfList.Items {
+					if wf.Name == workflowName {
+						workflowID = wf.ID
+						break
+					}
+				}
+
+				if workflowID != "" {
+					return workflowID, nil
+				}
+
+				if wfList.NextPageToken != "" {
+					token = wfList.NextPageToken
+				} else {
 					break
 				}
 			}

--- a/server/circleci.go
+++ b/server/circleci.go
@@ -227,11 +227,10 @@ func (s *Server) waitForWorkflowID(ctx context.Context, id string, workflowName 
 					return workflowID, nil
 				}
 
-				if wfList.NextPageToken != "" {
-					token = wfList.NextPageToken
-				} else {
+				if wfList.NextPageToken == "" {
 					break
 				}
+				token = wfList.NextPageToken
 			}
 
 			if workflowID == "" {


### PR DESCRIPTION
Look for the page token and go through all the pages
until we get the workflow id.

We also bring back the API retry logic which got removed
when we moved to use the circleCI API.

https://mattermost.atlassian.net/browse/MM-27539
