### PR TITLE
Bump page number while continuing in case of error

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -223,6 +223,13 @@ func (s *Server) Tick() {
 			if err != nil {
 				mlog.Error("Failed to get PRs", mlog.Err(err), mlog.String("repo_owner", repository.Owner), mlog.String("repo_name", repository.Name))
 				s.Metrics.IncreaseCronTaskErrors("tick")
+				if resp.NextPage == 0 {
+					break
+				}
+				// It is likely that we have hit a rate-limit error,
+				// so we sleep a bit to let some time go by.
+				time.Sleep(200 * time.Millisecond)
+				prListOpts.Page = resp.NextPage
 				continue
 			}
 			if resp.NextPage == 0 {
@@ -247,6 +254,8 @@ func (s *Server) Tick() {
 			}
 		}
 
+		time.Sleep(time.Second)
+
 		issueListOpts := &github.IssueListByRepoOptions{
 			State:       "open",
 			ListOptions: github.ListOptions{PerPage: 50},
@@ -257,6 +266,13 @@ func (s *Server) Tick() {
 			if err != nil {
 				mlog.Error("Failed to get issues", mlog.Err(err), mlog.String("repo_owner", repository.Owner), mlog.String("repo_name", repository.Name))
 				s.Metrics.IncreaseCronTaskErrors("tick")
+				if resp.NextPage == 0 {
+					break
+				}
+				// It is likely that we have hit a rate-limit error,
+				// so we sleep a bit to let some time go by.
+				time.Sleep(200 * time.Millisecond)
+				issueListOpts.Page = resp.NextPage
 				continue
 			}
 			if resp.NextPage == 0 {


### PR DESCRIPTION
If a rate limit error occurs, we would just blindly retry that request
without incrementing the page number. This would keep retrying the same page
until GH would eventually return a proper response or return NextPage = 0.

A better way is to move on to the next page so that even if an error occurs,
we eventually converge to getting out of the loop.

While here, we also add some sleeps to better manage rate limit errors.
Ideally, we would just tune the burst rate, but for now we are sharing the same config
for both Job server and API server. To keep things simple, we change the code.
