### PR TITLE
Simplify release publishing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,70 @@
+before:
+  hooks:
+    - go mod download
+    - go mod verify
+builds:
+  - main: ./cmd/mattermost-mattermod
+    id: "mattermod"
+    binary: bin/mattermod
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/mattermost/mattermost-mattermod/version.version=v{{.Version}}
+      - -X github.com/mattermost/mattermost-mattermod/version.commitHash={{.FullCommit}}
+      - -X github.com/mattermost/mattermost-mattermod/version.buildDate={{.Date}}
+    env:
+      - CGO_ENABLED=0
+  - main: ./cmd/jobserver
+    id: "jobserver"
+    binary: bin/jobserver
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/mattermost/mattermost-mattermod/version.version=v{{.Version}}
+      - -X github.com/mattermost/mattermost-mattermod/version.commitHash={{.FullCommit}}
+      - -X github.com/mattermost/mattermost-mattermod/version.buildDate={{.Date}}
+    env:
+      - CGO_ENABLED=0
+  - main: ./cmd/migrator
+    id: "migrator"
+    binary: bin/migrator
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/mattermost/mattermost-mattermod/version.version=v{{.Version}}
+      - -X github.com/mattermost/mattermost-mattermod/version.commitHash={{.FullCommit}}
+      - -X github.com/mattermost/mattermost-mattermod/version.buildDate={{.Date}}
+    env:
+      - CGO_ENABLED=0
+archives:
+  -
+    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    wrap_in_directory: true
+    format: tar.gz
+    files:
+      - LICENSE
+      - README.md
+      - config/config-mattermod.default.json
+changelog:
+  sort: desc
+release:
+  github:
+    owner: mattermost
+    name: mattermost-mattermod
+  name_template: "{{ .ProjectName }}-v{{ .Version }}"
+  disable: false

--- a/Makefile
+++ b/Makefile
@@ -175,9 +175,8 @@ publish-release:
 			echo "aborting make publish-release."; \
 			exit -1; \
 		fi; \
-	else \
-		goreleaser --rm-dist; \
 	fi; \
+	goreleaser --rm-dist; \
 
 # Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:

--- a/Makefile
+++ b/Makefile
@@ -152,17 +152,17 @@ release:
 ## Prepare Patch release
 .PHONY: patch
 patch: PATTERN = '\$$1\".\"\$$2\".\"\$$3+1'
-patch: release
+patch: release publish-release
 
 ## Prepare Minor release
 .PHONY: minor
 minor: PATTERN = '\$$1\".\"\$$2+1\".0\"'
-minor: release
+minor: release publish-release
 
 ## Prepare Major release
 .PHONY: major
 major: PATTERN = '\$$1+1\".0.0\"'
-major: release
+major: release publish-release
 
 ## Build and publish release using Goreleaser.
 .PHONY: publish-release

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,21 @@ minor: release
 major: PATTERN = '\$$1+1\".0.0\"'
 major: release
 
+## Build and publish release using Goreleaser.
+.PHONY: publish-release
+publish-release:
+	@if ! [ -x "$$(command -v goreleaser)" ]; then \
+		echo "goreleaser is not installed, do you want to download it? [y/N] " && read ans && [ $${ans:-N} = y ]; \
+		if [ $$ans = y ] || [ $$ans = Y ]  ; then \
+			curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh; \
+		else \
+			echo "aborting make publish-release."; \
+			exit -1; \
+		fi; \
+	else \
+		goreleaser --rm-dist; \
+	fi; \
+
 # Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
 	@cat Makefile | grep -v '\.PHONY' |  grep -v '\help:' | grep -B1 -E '^[a-zA-Z_.-]+:.*' | sed -e "s/:.*//" | sed -e "s/^## //" |  grep -v '\-\-' | uniq | sed '1!G;h;$$!d' | awk 'NR%2{printf "\033[36m%-30s\033[0m",$$0;next;}1' | sort


### PR DESCRIPTION
#### Summary

PR adds a `publish-release` target to the `Makefile` that uses [Goreleaser](https://goreleaser.com/) to simplify the publishing of new releases.
This was used to generate [v0.5.0](https://github.com/mattermost/mattermost-mattermod/releases/tag/v0.5.0).
