### PR TITLE
Add 'hacktoberfest-accepted' label instead of 'hacktoberfest' label in PRs

### DIFF
--- a/server/community.go
+++ b/server/community.go
@@ -29,9 +29,9 @@ func (s *Server) addHacktoberfestLabel(ctx context.Context, pr *model.PullReques
 		return
 	}
 
-	_, _, err := s.GithubClient.Issues.AddLabelsToIssue(ctx, pr.RepoOwner, pr.RepoName, pr.Number, []string{"Hacktoberfest"})
+	_, _, err := s.GithubClient.Issues.AddLabelsToIssue(ctx, pr.RepoOwner, pr.RepoName, pr.Number, []string{"Hacktoberfest-Accepted"})
 	if err != nil {
-		mlog.Error("Error applying Hacktoberfest label", mlog.Err(err), mlog.Int("PR", pr.Number), mlog.String("Repo", pr.RepoName))
+		mlog.Error("Error applying Hacktoberfest-Accepted label", mlog.Err(err), mlog.Int("PR", pr.Number), mlog.String("Repo", pr.RepoName))
 		return
 	}
 }

--- a/server/community.go
+++ b/server/community.go
@@ -29,9 +29,9 @@ func (s *Server) addHacktoberfestLabel(ctx context.Context, pr *model.PullReques
 		return
 	}
 
-	_, _, err := s.GithubClient.Issues.AddLabelsToIssue(ctx, pr.RepoOwner, pr.RepoName, pr.Number, []string{"Hacktoberfest-Accepted"})
+	_, _, err := s.GithubClient.Issues.AddLabelsToIssue(ctx, pr.RepoOwner, pr.RepoName, pr.Number, []string{"Hacktoberfest", "hacktoberfest-accepted"})
 	if err != nil {
-		mlog.Error("Error applying Hacktoberfest-Accepted label", mlog.Err(err), mlog.Int("PR", pr.Number), mlog.String("Repo", pr.RepoName))
+		mlog.Error("Error applying Hacktoberfest labels", mlog.Err(err), mlog.Int("PR", pr.Number), mlog.String("Repo", pr.RepoName))
 		return
 	}
 }


### PR DESCRIPTION
See https://hacktoberfest.digitalocean.com/hacktoberfest-update

If a PR is deemed invalid, we can simply remove this label and add the 'invalid' label instead.
