### PR TITLE
Temporary reduce prod replicas to 1 due to pvc issue

### DIFF
--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
   - pvc.yaml
 
 patchesStrategicMerge:
-  - patches/deployment-replicas.yaml
+  # - patches/deployment-replicas.yaml
   - patches/deployment-data-pvc.yaml
   - patches/deployment-gitconfig.yaml
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Currently, there are 3 replicas in production with one PVC shared with all of them. This PVC has to be of type `ReadWriteOnce` because all of the pods need to be able to write to it and as such, the volume is _bound_ to one specific node and there have been multiple `FailedScheduling` issues in the past couple of deployments. This is to reduce the replicas to 1 (for now) to make the pod _moveable_ between nodes.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

