### PR TITLE
Use *int64 for PullRequest.MilestoneNumber

### DIFF
--- a/model/pull_request.go
+++ b/model/pull_request.go
@@ -31,6 +31,6 @@ type PullRequest struct {
 	Merged              sql.NullBool
 	MergeCommitSHA      string `db:"-"`
 	MaintainerCanModify sql.NullBool
-	MilestoneNumber     sql.NullInt64
+	MilestoneNumber     *int64
 	MilestoneTitle      sql.NullString
 }

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -137,9 +137,9 @@ func (s *Server) checkIfNeedCherryPick(pr *model.PullRequest) {
 		return
 	}
 
-	if !pr.MilestoneNumber.Valid ||
+	if pr.MilestoneNumber == nil ||
 		!pr.MilestoneTitle.Valid ||
-		pr.MilestoneNumber.Int64 == 0 ||
+		*pr.MilestoneNumber == 0 ||
 		pr.MilestoneTitle.String == "" {
 		mlog.Info("PR milestone number not available", mlog.Int("PR Number", pr.Number), mlog.String("Repo", pr.RepoName))
 		return
@@ -153,7 +153,7 @@ func (s *Server) checkIfNeedCherryPick(pr *model.PullRequest) {
 	prLabels := labelsToStringArray(labels)
 	for _, prLabel := range prLabels {
 		if prLabel == "CherryPick/Approved" {
-			milestoneNumber := int(pr.MilestoneNumber.Int64)
+			milestoneNumber := int(*pr.MilestoneNumber)
 			milestone := getMilestone(pr.MilestoneTitle.String)
 
 			select {

--- a/server/github.go
+++ b/server/github.go
@@ -38,7 +38,7 @@ func (s *Server) GetPullRequestFromGithub(ctx context.Context, pullRequest *gith
 		Merged:              sql.NullBool{Bool: pullRequest.GetMerged(), Valid: true},
 		MergeCommitSHA:      pullRequest.GetMergeCommitSHA(),
 		MaintainerCanModify: sql.NullBool{Bool: pullRequest.GetMaintainerCanModify(), Valid: true},
-		MilestoneNumber:     sql.NullInt64{Int64: int64(pullRequest.GetMilestone().GetNumber()), Valid: true},
+		MilestoneNumber:     NewInt64(int64(pullRequest.GetMilestone().GetNumber())),
 		MilestoneTitle:      sql.NullString{String: pullRequest.GetMilestone().GetTitle(), Valid: true},
 	}
 

--- a/server/pr_from_issue_handler.go
+++ b/server/pr_from_issue_handler.go
@@ -32,7 +32,7 @@ func (s *Server) prFromIssueHandler(event *issueEvent, w http.ResponseWriter) {
 
 	// We update the milestone that we have from the issue event and merge it with the PR.
 	// This is necessary to work around caching issues with GitHub.
-	oldPR.MilestoneNumber = sql.NullInt64{Int64: int64(event.Issue.GetMilestone().GetNumber()), Valid: true}
+	oldPR.MilestoneNumber = NewInt64(int64(event.Issue.GetMilestone().GetNumber()))
 	oldPR.MilestoneTitle = sql.NullString{String: event.Issue.GetMilestone().GetTitle(), Valid: true}
 
 	_, err = s.Store.PullRequest().Save(oldPR)

--- a/server/pr_from_issue_handler_test.go
+++ b/server/pr_from_issue_handler_test.go
@@ -67,7 +67,7 @@ func TestPRFromIssueHandler(t *testing.T) {
 		State:               "closed",
 		Merged:              sql.NullBool{Bool: false, Valid: true},
 		MaintainerCanModify: sql.NullBool{Bool: false, Valid: true},
-		MilestoneNumber:     sql.NullInt64{Int64: int64(event.Issue.Milestone.GetNumber()), Valid: true},
+		MilestoneNumber:     NewInt64(int64(event.Issue.Milestone.GetNumber())),
 		MilestoneTitle:      sql.NullString{String: event.Issue.Milestone.GetTitle(), Valid: true},
 	})).
 		Times(1).Return(nil, nil)
@@ -84,7 +84,7 @@ func TestPRFromIssueHandler(t *testing.T) {
 			State:               "closed",
 			Merged:              sql.NullBool{Bool: false, Valid: true},
 			MaintainerCanModify: sql.NullBool{Bool: false, Valid: true},
-			MilestoneNumber:     sql.NullInt64{Int64: int64(0), Valid: true},
+			MilestoneNumber:     NewInt64(0),
 			MilestoneTitle:      sql.NullString{String: "release-5.28", Valid: true},
 		}, nil)
 

--- a/server/pull_request_handler.go
+++ b/server/pull_request_handler.go
@@ -308,7 +308,7 @@ func (s *Server) checkPullRequestForChanges(ctx context.Context, pr *model.PullR
 		prHasChanges = true
 	}
 
-	if !oldPr.MilestoneNumber.Valid || (oldPr.MilestoneNumber.Int64 != pr.MilestoneNumber.Int64) {
+	if oldPr.MilestoneNumber == nil || pr.MilestoneNumber == nil || (*oldPr.MilestoneNumber != *pr.MilestoneNumber) {
 		prHasChanges = true
 	}
 


### PR DESCRIPTION
#### Summary
Updates `MilestoneNumber` field to be `*int64` instead of `sql.NullInt64`

#### Ticket Link

JIRA: https://mattermost.atlassian.net/browse/MM-26814
https://github.com/mattermost/mattermost-server/issues/16975

