### PR TITLE
Dereference pointers when comparing MaintainerCanModify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ deploy/overlays/prod/ssh/
 out/
 
 dist/
+
+.idea/

--- a/server/pull_request_handler.go
+++ b/server/pull_request_handler.go
@@ -300,7 +300,7 @@ func (s *Server) checkPullRequestForChanges(ctx context.Context, pr *model.PullR
 		prHasChanges = true
 	}
 
-	if !oldPr.MaintainerCanModify.Valid || oldPr.MaintainerCanModify != pr.MaintainerCanModify {
+	if !oldPr.MaintainerCanModify.Valid || oldPr.MaintainerCanModify.Bool != pr.MaintainerCanModify.Bool {
 		prHasChanges = true
 	}
 

--- a/server/pull_request_handler.go
+++ b/server/pull_request_handler.go
@@ -300,7 +300,7 @@ func (s *Server) checkPullRequestForChanges(ctx context.Context, pr *model.PullR
 		prHasChanges = true
 	}
 
-	if oldPr.MaintainerCanModify == nil || pr.MaintainerCanModify == nil || (*oldPr.MaintainerCanModify != *pr.MaintainerCanModify) {
+	if !oldPr.MaintainerCanModify.Valid || oldPr.MaintainerCanModify != pr.MaintainerCanModify {
 		prHasChanges = true
 	}
 

--- a/server/pull_request_handler.go
+++ b/server/pull_request_handler.go
@@ -300,7 +300,7 @@ func (s *Server) checkPullRequestForChanges(ctx context.Context, pr *model.PullR
 		prHasChanges = true
 	}
 
-	if oldPr.MaintainerCanModify == nil || (oldPr.MaintainerCanModify != pr.MaintainerCanModify) {
+	if oldPr.MaintainerCanModify == nil || pr.MaintainerCanModify == nil || (*oldPr.MaintainerCanModify != *pr.MaintainerCanModify) {
 		prHasChanges = true
 	}
 

--- a/server/pull_request_handler_test.go
+++ b/server/pull_request_handler_test.go
@@ -339,7 +339,7 @@ func TestPullRequestEventHandler(t *testing.T) {
 				Number: NewInt(int(modelPR.MilestoneNumber.Int64)),
 				Title:  &modelPR.MilestoneTitle.String,
 			},
-			MaintainerCanModify: NewBool(false),
+			MaintainerCanModify: NewBool(!modelPR.MaintainerCanModify.Bool),
 		}
 
 		testPRHasChanges(t, modelPR, githubPR, 2)

--- a/server/pull_request_handler_test.go
+++ b/server/pull_request_handler_test.go
@@ -278,7 +278,7 @@ func TestPullRequestEventHandler(t *testing.T) {
 			Merged:              sql.NullBool{Bool: true, Valid: true},
 			MilestoneNumber:     sql.NullInt64{Valid: true, Int64: 0},
 			MilestoneTitle:      sql.NullString{Valid: true, String: ""},
-			MaintainerCanModify: &oldPRMaintainerCanModify,
+			MaintainerCanModify: sql.NullBool{Valid: true, Bool: oldPRMaintainerCanModify},
 		}
 
 		prStoreMock.EXPECT().Get("mattertest", "mattermod", 1).


### PR DESCRIPTION
#### Summary
Right now we're comparing pointers which is probably not the behavior we want

```go
// server/pull_request_handler.go

//...
if oldPr.MaintainerCanModify == nil || (oldPr.MaintainerCanModify != pr.MaintainerCanModify) {
	prHasChanges = true
}
//...
```
I was gonna commit the change in #257 but I wasn't quick enough :)
#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-26814
