### PR TITLE
remove temporary file when running on macos

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -59,6 +59,9 @@ CLOSEST_VERSION=$(getClosestVersion)
 
 # Bump the released version
 sed -i -E 's|'${CLOSEST_VERSION}'|'${RELEASE_VERSION}'|g' deploy/overlays/prod/kustomization.yaml
+# On FreeBSD sed versions, -i takes an argument, so it creates a backup file with the next argument, which happens to be -E in this case. Hence, to keep things simple, we just delete the backup file.
+# Just -i does not work on MacOS, and -i '' does not work on GNU. Hence we are stuck with this quirk.
+rm -f deploy/overlays/prod/kustomization.yaml-E
 
 # Commit changes
 printf "\033[36m==> %s\033[0m\n" "Commit changes for release version v${RELEASE_VERSION}"


### PR DESCRIPTION
#### Summary
when I was running the release notice the goreleaser part failed because the repository was dirty,
on macOS looks like when doing the sed part it generates a temporary file.
This PR removes that file to not fail the release process


The error log below
```
$ make minor
==> Commit changes for release version v0.7.0
[master e195ade] Release version v0.7.0
 1 file changed, 2 insertions(+), 2 deletions(-)
==> Push commits for v0.7.0
Enumerating objects: 11, done.
Counting objects: 100% (11/11), done.
Delta compression using up to 16 threads
Compressing objects: 100% (6/6), done.
Writing objects: 100% (6/6), 1.14 KiB | 1.14 MiB/s, done.
Total 6 (delta 3), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
To github.com:mattermost/mattermost-mattermod.git
   5908daa..e195ade  master -> master
==> Tag release v0.7.0
==> Push tag release v0.7.0
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 167 bytes | 167.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:mattermost/mattermost-mattermod.git
 * [new tag]         v0.7.0 -> v0.7.0
   • releasing...
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • releasing v0.7.0, commit e195ade82d5c7fd3ec583b19df4f149f3a9cab49
   ⨯ release failed after 0.06s error=git is currently in a dirty state, please check in your pipeline what can be changing the following files:
?? deploy/overlays/prod/kustomization.yaml-E

make: *** [publish-release] Error 1
````

#### Ticket Link
n/a

