### PR TITLE
MM-36618: switch to assigning whole greeter team

### DIFF
--- a/server/community.go
+++ b/server/community.go
@@ -6,8 +6,6 @@ package server
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"math/rand"
 	"text/template"
 	"time"
 
@@ -79,26 +77,13 @@ func (s *Server) assignGreeter(ctx context.Context, pr *model.PullRequest, repo 
 		return nil
 	}
 
-	// get available members
-	greeterList, _, err := s.GithubClient.Teams.ListTeamMembersBySlug(ctx, s.Config.Org, repo.GreetingTeam, nil)
-	if err != nil {
-		return errors.Wrapf(err, "can't retrieve team members from %s", repo.GreetingTeam)
-	}
-
-	// Assign one of them as a reviewer
-	size := len(greeterList)
-	if size == 0 {
-		return fmt.Errorf("there were no members on the greeting team %s", repo.GreetingTeam)
-	}
-
-	greeter := greeterList[rand.Intn(size)]
 	greetingRequest := github.ReviewersRequest{
-		Reviewers: []string{*greeter.Login},
+		Reviewers: []string{repo.GreetingTeam},
 	}
 
-	_, _, err = s.GithubClient.PullRequests.RequestReviewers(ctx, pr.RepoOwner, pr.RepoName, pr.Number, greetingRequest)
+	_, _, err := s.GithubClient.PullRequests.RequestReviewers(ctx, pr.RepoOwner, pr.RepoName, pr.Number, greetingRequest)
 	if err != nil {
-		return errors.Wrapf(err, "couldn't assing a member of the greeting team %s", repo.GreetingTeam)
+		return errors.Wrapf(err, "couldn't assign the greeting team %s", repo.GreetingTeam)
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary
Instead of querying the configured `GreetingTeam`s members and assigning one at random, just assign the whole team, and rely on the GitHub team having been configured to auto-assign accordingly:

<img width="814" alt="image" src="https://user-images.githubusercontent.com/1023171/117152307-476aa780-ad90-11eb-9fd1-5a8380466442.png">

This approach automatically gets out "Out of office" support, since GitHub wont' assign a team member who's out of office. There's also a bunch of nice configuration options on GitHub, including the ability to restrict assignees to a subset of team members, and pick how many should be assigned.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-33618