### PR TITLE
DOPS-502 Add release-note block to cherry-pick script

### DIFF
--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -70,6 +70,11 @@ Automated cherry pick of #${PULL}
 Cherry pick of #${PULL} on ${rel}.
 
 /cc  @${ORIGINAL_AUTHOR}
+
+\`\`\`release-note
+NONE
+\`\`\`
+
 EOF
 
 hub pull-request -F "${prtext}" -h "${GITHUB_USER}:${NEWBRANCH}" -b "${MAIN_REPO_ORG}:${rel}"


### PR DESCRIPTION
#### Summary
This commit modifies the cherry-pick script to add the `release-note` block
with `NONE` to the PR body.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/DOPS-502

