### PR TITLE
return the correct workflow ID

### DIFF
--- a/server/circleci.go
+++ b/server/circleci.go
@@ -217,19 +217,16 @@ func (s *Server) waitForWorkflowID(ctx context.Context, id string, workflowName 
 				}
 
 				for _, wf := range wfList.Items {
-					if wf.Name == workflowName {
-						workflowID = wf.ID
-						break
+					if wf.Name == workflowName && wf.ID == id {
+						workflowID = wf.WorkflowID
+						return workflowID, nil
 					}
-				}
-
-				if workflowID != "" {
-					return workflowID, nil
 				}
 
 				if wfList.NextPageToken == "" {
 					break
 				}
+
 				token = wfList.NextPageToken
 			}
 

--- a/server/circleci_test.go
+++ b/server/circleci_test.go
@@ -188,11 +188,23 @@ func TestWaitForWorkflowID(t *testing.T) {
 				ProjectSlug: "github/mattermost/mattermod",
 			},
 		},
+		NextPageToken: "token2",
+	}
+	wfList3 := &circleci.WorkflowList{
+		Items: []circleci.WorkflowItem{
+			{
+				ID:          "pipelineID",
+				WorkflowID:  "foo",
+				Name:        "targetName",
+				ProjectSlug: "github/mattermost/mattermod",
+			},
+		},
 		NextPageToken: "",
 	}
 	circleCIService := mocks.NewMockCircleCIService(ctrl)
 	circleCIService.EXPECT().GetPipelineWorkflowWithContext(gomock.AssignableToTypeOf(ctxInterface), "pipelineID", "").Return(wfList1, nil)
 	circleCIService.EXPECT().GetPipelineWorkflowWithContext(gomock.AssignableToTypeOf(ctxInterface), "pipelineID", "token").Return(wfList2, nil)
+	circleCIService.EXPECT().GetPipelineWorkflowWithContext(gomock.AssignableToTypeOf(ctxInterface), "pipelineID", "token2").Return(wfList3, nil)
 
 	s := Server{
 		CircleCiClientV2: circleCIService,
@@ -200,5 +212,5 @@ func TestWaitForWorkflowID(t *testing.T) {
 
 	res, err := s.waitForWorkflowID(context.Background(), "pipelineID", "targetName")
 	require.NoError(t, err)
-	assert.Equal(t, "targetID", res)
+	assert.Equal(t, "foo", res)
 }


### PR DESCRIPTION
#### Summary
Previously we were returning the Id of the job that we triggered and not the workflow ID, this PR fix that

I test spinning a local bot and triggered and I got the correct URL to open in circleci



#### Ticket Link
n/a

