### PR TITLE
Do not review mlog changes for organization members

### DIFF
--- a/server/review.go
+++ b/server/review.go
@@ -20,6 +20,12 @@ import (
 const mlogReviewCommentBody = "Gentle reminder to check our logging [principles](https://developers.mattermost.com/contribute/server/style-guide/#log-levels) before merging this change."
 
 func (s *Server) reviewMlog(ctx context.Context, pr *model.PullRequest, nodeID, diffURL string) error {
+	for _, m := range s.OrgMembers {
+		if pr.Username == m {
+			return nil
+		}
+	}
+
 	b, err := getRawDiff(ctx, diffURL)
 	if err != nil {
 		return fmt.Errorf("could not retrieve diff: %w", err)

--- a/server/review.go
+++ b/server/review.go
@@ -20,10 +20,10 @@ import (
 const mlogReviewCommentBody = "Gentle reminder to check our logging [principles](https://developers.mattermost.com/contribute/server/style-guide/#log-levels) before merging this change."
 
 func (s *Server) reviewMlog(ctx context.Context, pr *model.PullRequest, nodeID, diffURL string) error {
-	for _, m := range s.OrgMembers {
-		if pr.Username == m {
-			return nil
-		}
+	// Do not review this for organization members. This was in use for a while
+	// and we can assume that people in the organization should be aware of the gudieline.
+	if s.IsOrgMember(pr.Username) {
+		return nil
 	}
 
 	b, err := getRawDiff(ctx, diffURL)

--- a/server/review_test.go
+++ b/server/review_test.go
@@ -56,6 +56,7 @@ func TestReviewMlog(t *testing.T) {
 		RepoOwner: "mattertestmost",
 		RepoName:  "mattermosttest",
 		Number:    1,
+		Username:  "testuser",
 	}
 
 	node := "test-node"
@@ -139,6 +140,16 @@ func TestReviewMlog(t *testing.T) {
 
 		prs.EXPECT().CreateReview(ctx, pr.RepoOwner, pr.RepoName, pr.Number, review).Times(1).Return(nil, nil, nil)
 		err := s.reviewMlog(ctx, pr, node, ts.URL)
+		require.NoError(t, err)
+	})
+
+	t.Run("Should not comment on organization member PRs", func(t *testing.T) {
+		s.OrgMembers = append(s.OrgMembers, "testuser")
+		t.Cleanup(func() {
+			s.OrgMembers = s.OrgMembers[:len(s.OrgMembers)-1]
+		})
+
+		err := s.reviewMlog(context.Background(), pr, node, "")
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION

#### Summary

I think everyone should be aware of the logging guidelines so far. Let's review this for non-org members.

