### PR TITLE
changes in ci and upgrade to go 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,16 @@ orbs:
 executors:
   default:
     docker:
-      - image: circleci/golang:1.14
+      - image: cimg/go:1.17
 
 jobs:
   lint:
-    executor:
-      name: default
+    docker:
+      - image: golangci/golangci-lint:v1.27.0
     steps:
       - checkout
-      - tools/install-golangci-lint:
-          version: "1.27.0"
-      - run: make check-style
+      - run:
+          command: make check-style
 
   build:
     executor:
@@ -43,7 +42,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/golang:1.14
+      - image: cimg/go:1.17
       - image: circleci/mysql:5.7
         environment:
           MYSQL_ROOT_PASSWORD: mattermod
@@ -64,39 +63,9 @@ jobs:
             echo Failed waiting for MySQL && exit 1
       - run: make test
 
-  docker:
-    parameters:
-      target:
-        type: string
-    docker:
-      - image: circleci/buildpack-deps:stretch
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Build docker image
-          command: |
-            if [ -z "<<parameters.target>>" ]; then
-              echo "'target' is missing"
-              exit 1
-            fi
-            if [ "<<parameters.target>>" == "pr" ]; then
-              export TAG_NAME=$(echo "${CIRCLE_SHA1}" | cut -c1-8)
-              DOCKER_TAG=${TAG_NAME} make docker
-            else
-              echo ${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin
-              if [ "<<parameters.target>>" == "edge" ]; then
-                DOCKER_TAG=edge make docker push
-              elif [ "<<parameters.target>>" == "latest" ]; then
-                export TAG_NAME=$(echo "${CIRCLE_TAG}" | tr -d 'v')
-                DOCKER_TAG=${TAG_NAME} make docker push
-                DOCKER_TAG=latest make docker push
-              fi
-            fi
-
 workflows:
   version: 2
-  untagged-build:
+  ci-build:
     jobs:
       - lint
       - check-dependencies
@@ -107,33 +76,3 @@ workflows:
       - test:
           requires:
             - build
-      - docker:
-          name: docker-pr
-          context: matterbuild-docker
-          target: pr
-          requires:
-            - test
-          filters:
-            branches:
-              ignore: master
-      - docker:
-          name: docker-edge
-          context: matterbuild-docker
-          target: edge
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
-
-  release-build:
-    jobs:
-      - docker:
-          name: docker-latest
-          context: matterbuild-docker
-          target: latest
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,3 @@
 include:
-  - project: 'ci/mattermod'
+  - project: 'mattermost/ci/mattermod'
     file: '/all.yml'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.6-alpine AS builder
+FROM golang:1.17.2-alpine AS builder
 
 RUN apk add --update --no-cache ca-certificates bash make gcc musl-dev git openssh wget curl
 

--- a/Dockerfile.jobserver
+++ b/Dockerfile.jobserver
@@ -1,4 +1,4 @@
-FROM golang:1.14.6-alpine AS builder
+FROM golang:1.17.2-alpine AS builder
 
 RUN apk add --update --no-cache ca-certificates bash make gcc musl-dev git openssh wget curl
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost-mattermod
 
-go 1.14
+go 1.17
 
 require (
 	github.com/die-net/lrucache v0.0.0-20181227122439-19a39ef22a11
@@ -23,4 +23,34 @@ require (
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/francoispqt/gojay v1.2.13 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/mattermost/logr v1.0.5 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/common v0.10.0 // indirect
+	github.com/prometheus/procfs v0.1.3 // indirect
+	github.com/wiggin77/cfg v1.0.2 // indirect
+	github.com/wiggin77/merror v1.0.2 // indirect
+	github.com/wiggin77/srslog v1.0.1 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
+	go.uber.org/zap v1.15.0 // indirect
+	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
+	golang.org/x/sys v0.0.0-20200724161237-0e2f3a69832c // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -949,7 +949,6 @@ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fq
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -1150,7 +1149,6 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.tools.mod
+++ b/go.tools.mod
@@ -1,5 +1,5 @@
 module github.com/mattermost/mattermost-mattermod
 
-go 1.14
+go 1.17
 
 require github.com/kevinburke/go-bindata v3.22.0+incompatible // indirect


### PR DESCRIPTION
#### Summary
As part of the efforts to clean/update ci permissions, this pr removes the docker push from PRs and main branch and that will be moved to inside the internal GitLab

also, update to use go 1.17

The gitlab MR : https://git.internal.mattermost.com/mattermost/ci/mattermod/-/merge_requests/11

#### Ticket Link
n/a
