### PR TITLE
Extend polling interval to 30 secs instead of 5 secs

### DIFF
--- a/server/circleci.go
+++ b/server/circleci.go
@@ -99,7 +99,7 @@ func (s *Server) requestEETriggering(ctx context.Context, pr *model.PullRequest,
 	buildLink := "https://app.circleci.com/pipelines/github/" + s.Config.Org + "/" + s.Config.EnterpriseReponame + "/" + strconv.Itoa(r.Number) + "/workflows/" + workflowID
 	mlog.Debug("EE tests wf found", mlog.Int("pr", pr.Number), mlog.String("sha", pr.Sha), mlog.String("link", buildLink))
 
-	err = s.waitForStatus(ctx, pr, s.Config.EnterpriseGithubStatusContext, stateSuccess)
+	err = s.waitForStatus(ctx, pr, s.Config.EnterpriseGithubStatusContext, stateSuccess, 5*time.Second)
 	if err != nil {
 		s.createEnterpriseTestsErrorStatus(ctx, pr, err)
 		return err

--- a/server/e2e_test_command.go
+++ b/server/e2e_test_command.go
@@ -103,7 +103,7 @@ func (s *Server) handleE2ETest(ctx context.Context, commenter string, pr *model.
 
 	ctx2, cancel := context.WithTimeout(context.Background(), defaultE2ETestTimeout*time.Second)
 	defer cancel()
-	err = s.waitForStatus(ctx2, pr, ghStatusContext, stateSuccess, 30*time.Second) // 30 seconds to consider with the secondary rate limit interval of GitHub
+	err = s.waitForStatus(ctx2, pr, ghStatusContext, stateSuccess, 30*time.Second) // 30 seconds to consider the GitHub's secondary rate limit
 	if err != nil {
 		return err
 	}

--- a/server/e2e_test_command.go
+++ b/server/e2e_test_command.go
@@ -103,7 +103,7 @@ func (s *Server) handleE2ETest(ctx context.Context, commenter string, pr *model.
 
 	ctx2, cancel := context.WithTimeout(context.Background(), defaultE2ETestTimeout*time.Second)
 	defer cancel()
-	err = s.waitForStatus(ctx2, pr, ghStatusContext, stateSuccess, 30*time.Second) // 30 seconds to consider the GitHub's secondary rate limit
+	err = s.waitForStatus(ctx2, pr, ghStatusContext, stateSuccess, 30*time.Second) // 30 seconds to consider GitHub's secondary rate limit
 	if err != nil {
 		return err
 	}

--- a/server/e2e_test_command.go
+++ b/server/e2e_test_command.go
@@ -103,7 +103,7 @@ func (s *Server) handleE2ETest(ctx context.Context, commenter string, pr *model.
 
 	ctx2, cancel := context.WithTimeout(context.Background(), defaultE2ETestTimeout*time.Second)
 	defer cancel()
-	err = s.waitForStatus(ctx2, pr, ghStatusContext, stateSuccess)
+	err = s.waitForStatus(ctx2, pr, ghStatusContext, stateSuccess, 30*time.Second) // 30 seconds to consider with the secondary rate limit interval of GitHub
 	if err != nil {
 		return err
 	}

--- a/server/github.go
+++ b/server/github.go
@@ -332,7 +332,7 @@ func (s *Server) createRepoStatus(ctx context.Context, pr *model.PullRequest, st
 }
 
 func (s *Server) waitForStatus(ctx context.Context, pr *model.PullRequest, statusContext string, statusState string) error {
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(30 * time.Second) // extended to 30 seconds to go with the secondary rate limit interval of GitHub
 	for {
 		select {
 		case <-ctx.Done():

--- a/server/github.go
+++ b/server/github.go
@@ -331,8 +331,8 @@ func (s *Server) createRepoStatus(ctx context.Context, pr *model.PullRequest, st
 	return nil
 }
 
-func (s *Server) waitForStatus(ctx context.Context, pr *model.PullRequest, statusContext string, statusState string) error {
-	ticker := time.NewTicker(30 * time.Second) // extended to 30 seconds to go with the secondary rate limit interval of GitHub
+func (s *Server) waitForStatus(ctx context.Context, pr *model.PullRequest, statusContext string, statusState string, t time.Duration) error {
+	ticker := time.NewTicker(t)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
--> The waiting for a GitHub status polling stresses the secondary rate limit https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits.
Until we implement the `Retry-After` into the GitHubClientWithLimiter, let's decrease the stress. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

