### PR TITLE
Fixes for /e2e-cancel command

### DIFF
--- a/server/e2e_cancel.go
+++ b/server/e2e_cancel.go
@@ -46,7 +46,14 @@ func (s *Server) handleE2ECancel(ctx context.Context, commenter string, pr *mode
 		e2eErr = &E2ECancelError{source: e2eCancelMsgCommenterPermission}
 		return e2eErr
 	}
-	urls, err := s.cancelPipelinesForPR(ctx, &pr.Ref, &pr.Number)
+	var e2eProjectRef string
+	switch pr.RepoName {
+	case s.Config.E2EWebappReponame:
+		e2eProjectRef = s.Config.E2EWebappRef
+	case s.Config.E2EServerReponame:
+		e2eProjectRef = s.Config.E2EWebappRef
+	}
+	urls, err := s.cancelPipelinesForPR(ctx, &e2eProjectRef, &pr.Number)
 	if err != nil {
 		mlog.Warn("E2E cancellation failed")
 		e2eErr = &E2ECancelError{source: e2eCancelMsgFailedCancellation}

--- a/server/gitlab.go
+++ b/server/gitlab.go
@@ -195,16 +195,16 @@ func hasSameEnvs(info *E2ETestTriggerInfo, glVars []*gitlab.PipelineVariable) (b
 	return false, nil
 }
 
-func (s *Server) cancelPipelinesForPR(ctx context.Context, prRef *string, prNumber *int) ([]*string, error) { // pending, created, running
-	pipInfosC, err := s.findCancellablePipelines(ctx, gitlab.Created, prRef, prNumber)
+func (s *Server) cancelPipelinesForPR(ctx context.Context, e2eProjectRef *string, prNumber *int) ([]*string, error) { // pending, created, running
+	pipInfosC, err := s.findCancellablePipelines(ctx, gitlab.Created, e2eProjectRef, prNumber)
 	if err != nil {
 		return nil, err
 	}
-	pipInfosP, err := s.findCancellablePipelines(ctx, gitlab.Pending, prRef, prNumber)
+	pipInfosP, err := s.findCancellablePipelines(ctx, gitlab.Pending, e2eProjectRef, prNumber)
 	if err != nil {
 		return nil, err
 	}
-	pipInfosR, err := s.findCancellablePipelines(ctx, gitlab.Running, prRef, prNumber)
+	pipInfosR, err := s.findCancellablePipelines(ctx, gitlab.Running, e2eProjectRef, prNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -238,10 +238,10 @@ func (s *Server) cancelPipelinesForPR(ctx context.Context, prRef *string, prNumb
 	return urls, nil
 }
 
-func (s *Server) findCancellablePipelines(ctx context.Context, state gitlab.BuildStateValue, prRef *string, prNumber *int) ([]*gitlab.PipelineInfo, error) {
+func (s *Server) findCancellablePipelines(ctx context.Context, state gitlab.BuildStateValue, e2eProjectRef *string, prNumber *int) ([]*gitlab.PipelineInfo, error) {
 	listOpts := &gitlab.ListProjectPipelinesOptions{
 		Status: gitlab.BuildState(state),
-		Ref:    prRef,
+		Ref:    e2eProjectRef,
 	}
 	pips, _, err := s.GitLabCIClientV4.Pipelines.ListProjectPipelines(s.Config.E2EGitLabProject, listOpts, gitlab.WithContext(ctx))
 	if err != nil {

--- a/server/issue_comment_handler.go
+++ b/server/issue_comment_handler.go
@@ -161,7 +161,7 @@ func (e *issueCommentEvent) HasE2ETest() bool {
 	return strings.Contains(strings.TrimSpace(e.Comment.GetBody()), "/e2e-test")
 }
 
-// HasE2ECancel is true if body contains "/e2e-cancel"
+// HasE2ECancel is true if body is prefixed with "/e2e-cancel"
 func (e *issueCommentEvent) HasE2ECancel() bool {
 	return strings.HasPrefix(strings.TrimSpace(e.Comment.GetBody()), "/e2e-cancel")
 }

--- a/server/issue_comment_handler.go
+++ b/server/issue_comment_handler.go
@@ -163,5 +163,5 @@ func (e *issueCommentEvent) HasE2ETest() bool {
 
 // HasE2ECancel is true if body contains "/e2e-cancel"
 func (e *issueCommentEvent) HasE2ECancel() bool {
-	return strings.Contains(strings.TrimSpace(e.Comment.GetBody()), "/e2e-cancel")
+	return strings.HasPrefix(strings.TrimSpace(e.Comment.GetBody()), "/e2e-cancel")
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Fix when bot comments, /e2e-cancel command gets run :grimacing:  
- Fix listing pipelines for wrong ref, so no pipelines were found (pr ref instead of e2e-webapp-pr ref in the cypress project)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

