### PR TITLE
Fix polling for github status for e2e testing.

### DIFF
--- a/server/e2e_test_command.go
+++ b/server/e2e_test_command.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/mattermost/mattermost-mattermod/model"
 	"github.com/mattermost/mattermost-server/v5/mlog"
@@ -242,7 +241,7 @@ func (s *Server) waitForImageStatus(pr *model.PullRequest) (bool, error) {
 		ghStatusContext = s.Config.E2EServerStatusContext
 	}
 
-	ctx2, cancel := context.WithDeadline(context.Background(), time.Now().Add(s.Config.E2ETestDeadline))
+	ctx2, cancel := context.WithTimeout(context.Background(), s.Config.E2ETestDeadline)
 	defer cancel()
 	err := s.waitForStatus(ctx2, pr, ghStatusContext, stateSuccess, s.Config.E2EGitHubRateLimitHack)
 	if err != nil {

--- a/server/e2e_test_command_test.go
+++ b/server/e2e_test_command_test.go
@@ -167,7 +167,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		}
 		p := &gitlab.Pipeline{WebURL: "https://your.gitlab.com/project/-/pipelines/54004"}
 		pr.FullName = organization + "/" + userHandle
-		rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Ref, nil).Times(1).Return([]*github.RepoStatus{
+		rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).Times(1).Return([]*github.RepoStatus{
 			{
 				State:   github.String(stateSuccess),
 				Context: &s.Config.E2EWebappStatusContext,
@@ -284,13 +284,13 @@ func TestHandleE2ETesting(t *testing.T) {
 		}
 		p := &gitlab.Pipeline{WebURL: "https://your.gitlab.com/project/-/pipelines/54004"}
 		pr.FullName = organization + "/" + userHandle
-		first := rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Ref, nil).Times(1).Return([]*github.RepoStatus{
+		first := rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).Times(1).Return([]*github.RepoStatus{
 			{
 				State:   github.String(stateError),
 				Context: &s.Config.E2EWebappStatusContext,
 			},
 		}, nil, nil)
-		second := rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Ref, nil).Times(1).Return([]*github.RepoStatus{
+		second := rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).Times(1).Return([]*github.RepoStatus{
 			{
 				State:   github.String(stateSuccess),
 				Context: &s.Config.E2EWebappStatusContext,
@@ -416,7 +416,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		p := &gitlab.Pipeline{WebURL: "https://your.gitlab.com/project/-/pipelines/54004"}
 		pr.FullName = organization + "/" + userHandle
 		rs.EXPECT().
-			ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Ref, nil).
+			ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).
 			Times(1).
 			Return([]*github.RepoStatus{
 				{
@@ -601,7 +601,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		}
 		pr.FullName = organization + "/" + userHandle
 		rs.EXPECT().
-			ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Ref, nil).
+			ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).
 			Times(5).
 			Return([]*github.RepoStatus{
 				{
@@ -792,7 +792,7 @@ func TestHandleE2ETesting(t *testing.T) {
 			},
 		}
 		pr.FullName = organization + "/" + userHandle
-		rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Ref, nil).Times(1).Return([]*github.RepoStatus{
+		rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).Times(1).Return([]*github.RepoStatus{
 			{
 				State:   github.String(stateSuccess),
 				Context: &s.Config.E2EWebappStatusContext,

--- a/server/github.go
+++ b/server/github.go
@@ -340,7 +340,7 @@ func (s *Server) waitForStatus(ctx context.Context, pr *model.PullRequest, statu
 			return ctx.Err()
 		case t := <-ticker.C:
 			mlog.Debug("Waiting for status", mlog.Int("pr", pr.Number), mlog.String("context", statusContext), mlog.String("ticker", t.String()))
-			statuses, _, err := s.GithubClient.Repositories.ListStatuses(ctx, pr.RepoOwner, pr.RepoName, pr.Ref, nil)
+			statuses, _, err := s.GithubClient.Repositories.ListStatuses(ctx, pr.RepoOwner, pr.RepoName, pr.Sha, nil)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->I merged this PR (https://github.com/mattermost/mattermost-mattermod/pull/299/files) recently to fix the e2e-test spam messages, when a PR is not in a ready state. 
Turns out that polling now for the CI status is completely broken. 
Honestly, I am guessing on what the fix is. The answer is immediate, there is no attempt or log message to even try to poll. It might be that I tried to use the `context.WithDeadline` compared to what we usually use is `context.WithTimeout`. I also unnecessarily changed getting instead of the list of statuses for the sha to ref, which I also revert with this PR. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
