### PR TITLE
Revert using combined status instead of specific github status context.

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/pkg/errors"
@@ -19,6 +18,7 @@ const (
 	defaultEETaskTimeout   = 300
 	defaultCronTaskTimeout = 600
 	defaultBuildAppTimeout = 7200
+	defaultE2ETestTimeout  = 7200
 )
 
 type LabelResponse struct {
@@ -93,8 +93,6 @@ type Config struct {
 	E2EServerReponame      string
 	E2EWebappStatusContext string
 	E2EServerStatusContext string
-	E2ETestDeadline        time.Duration
-	E2EGitHubRateLimitHack time.Duration
 
 	EnterpriseReponame            string
 	EnterpriseTriggerReponame     string

--- a/server/e2e_test_command.go
+++ b/server/e2e_test_command.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/mattermost/mattermost-mattermod/model"
 	"github.com/mattermost/mattermost-server/v5/mlog"
@@ -13,7 +14,8 @@ import (
 
 const (
 	e2eTestMsgCommenterPermission = "You don't have permissions to trigger this command.\n It's only available for organization members."
-	e2eTestMsgCIFailing           = "The command /e2e-test requires the build docker check to pass."
+	e2eTestMsgCIFailing           = "The command /e2e-test requires all PR checks to pass."
+	e2eTestMsgUnknownPRState      = "Failed to check whether PR checks passed. E2E testing isn't triggered. Please retry later."
 	e2eTestMsgPRInfo              = "Failed to get the PR information required to trigger testing. Please retry later."
 	e2eTestMsgUnknownTriggerRepo  = "The ability to trigger E2E testing pipelines for this repository isn't set up. \n Please contact a maintainer."
 	e2eTestMsgTrigger             = "Failed to trigger E2E testing pipeline."
@@ -32,6 +34,8 @@ func (e *E2ETestError) Error() string {
 		return "commenter does not have permissions"
 	case e2eTestMsgCIFailing:
 		return "PR checks needs to be passing"
+	case e2eTestMsgUnknownPRState:
+		return "unknown PR state"
 	case e2eTestMsgPRInfo:
 		return "could not fetch PR info"
 	case e2eTestMsgUnknownTriggerRepo:
@@ -79,11 +83,27 @@ func (s *Server) handleE2ETest(ctx context.Context, commenter string, pr *model.
 	}
 	prRepoOwner, prRepoName, prNumber := pr.RepoOwner, pr.RepoName, pr.Number
 
-	passes, err := s.waitForImageStatus(pr)
-	if !passes {
+	isCIPassing, err := s.areChecksSuccessfulForPR(ctx, pr)
+	if err != nil {
+		e2eTestErr = &E2ETestError{source: e2eTestMsgUnknownPRState}
+		return e2eTestErr
+	}
+	if !isCIPassing {
 		e2eTestErr = &E2ETestError{source: e2eTestMsgCIFailing}
 		return e2eTestErr
 	}
+
+	ghStatusContext := ""
+	switch prRepoName {
+	case s.Config.E2EWebappReponame:
+		ghStatusContext = s.Config.E2EWebappStatusContext
+	case s.Config.E2EServerReponame:
+		ghStatusContext = s.Config.E2EServerStatusContext
+	}
+
+	ctx2, cancel := context.WithTimeout(context.Background(), defaultE2ETestTimeout*time.Second)
+	defer cancel()
+	err = s.waitForStatus(ctx2, pr, ghStatusContext, stateSuccess, 30*time.Second) // 30 seconds to consider GitHub's secondary rate limit
 	if err != nil {
 		return err
 	}
@@ -230,23 +250,4 @@ func (s *Server) getBranchAndSHAWithSameName(ctx context.Context, owner string, 
 		return "", "", errors.New("unexpected failure case")
 	}
 	return ghBranch.GetName(), ghBranch.GetCommit().GetSHA(), nil
-}
-
-func (s *Server) waitForImageStatus(pr *model.PullRequest) (bool, error) {
-	ghStatusContext := ""
-	switch pr.RepoName {
-	case s.Config.E2EWebappReponame:
-		ghStatusContext = s.Config.E2EWebappStatusContext
-	case s.Config.E2EServerReponame:
-		ghStatusContext = s.Config.E2EServerStatusContext
-	}
-
-	ctx2, cancel := context.WithTimeout(context.Background(), s.Config.E2ETestDeadline)
-	defer cancel()
-	err := s.waitForStatus(ctx2, pr, ghStatusContext, stateSuccess, s.Config.E2EGitHubRateLimitHack)
-	if err != nil {
-		return false, err
-	}
-
-	return true, nil
 }

--- a/server/e2e_test_command_test.go
+++ b/server/e2e_test_command_test.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/xanzy/go-gitlab"
 
@@ -83,43 +82,43 @@ func TestParseE2ETestCommentForOpts(t *testing.T) {
 }
 
 func TestHandleE2ETesting(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	const userHandle = "user"
+	const organization = "mattertest"
+	s := Server{
+		Config: &Config{
+			Org:                    organization,
+			E2EGitLabProject:       "qa%2Fcypress",
+			E2EWebappReponame:      "mattermost-webapp",
+			E2EServerReponame:      "mattermost-server",
+			E2EWebappRef:           "e2e-webapp-pr",
+			E2EServerRef:           "e2e-server-pr",
+			E2EDockerRepo:          "mattermost/mm-ee-test",
+			E2EServerStatusContext: "ee/circleci",
+			E2EWebappStatusContext: "ci/circleci: build-docker",
+		},
+		GithubClient:     &GithubClient{},
+		GitLabCIClientV4: &GitLabClient{},
+	}
+
+	ctx := context.Background()
+
+	msg := new(string)
+	comment := &github.IssueComment{Body: msg}
+	is := mocks.NewMockIssuesService(ctrl)
+	rs := mocks.NewMockRepositoriesService(ctrl)
+	prs := mocks.NewMockPullRequestsService(ctrl)
+	glPS := mocks.NewMockPipelinesService(ctrl)
+	s.GithubClient.Issues = is
+	s.GithubClient.Repositories = rs
+	s.GithubClient.PullRequests = prs
+	s.GitLabCIClientV4.Pipelines = glPS
+
+	gCtxInterface := reflect.TypeOf(gitlab.RequestOptionFunc(nil))
+	ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
+
 	t.Run("happy trigger from webapp", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-
-		const userHandle = "user"
-		const organization = "mattertest"
-		s := Server{
-			Config: &Config{
-				Org:                    organization,
-				E2EGitLabProject:       "qa%2Fcypress",
-				E2EWebappReponame:      "mattermost-webapp",
-				E2EServerReponame:      "mattermost-server",
-				E2EWebappRef:           "e2e-webapp-pr",
-				E2EServerRef:           "e2e-server-pr",
-				E2EDockerRepo:          "mattermost/mm-ee-test",
-				E2EServerStatusContext: "ee/circleci",
-				E2EWebappStatusContext: "ci/circleci: build-docker",
-				E2ETestDeadline:        5 * time.Second,
-				E2EGitHubRateLimitHack: 1 * time.Second,
-			},
-			GithubClient:     &GithubClient{},
-			GitLabCIClientV4: &GitLabClient{},
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
-		defer cancel()
-		is := mocks.NewMockIssuesService(ctrl)
-		rs := mocks.NewMockRepositoriesService(ctrl)
-		prs := mocks.NewMockPullRequestsService(ctrl)
-		glPS := mocks.NewMockPipelinesService(ctrl)
-		s.GithubClient.Issues = is
-		s.GithubClient.Repositories = rs
-		s.GithubClient.PullRequests = prs
-		s.GitLabCIClientV4.Pipelines = glPS
-
-		gCtxInterface := reflect.TypeOf(gitlab.RequestOptionFunc(nil))
-		ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
-
 		commentBody := commandE2ETestBase
 		s.OrgMembers = make([]string, 1)
 		s.OrgMembers[0] = userHandle
@@ -167,6 +166,12 @@ func TestHandleE2ETesting(t *testing.T) {
 		}
 		p := &gitlab.Pipeline{WebURL: "https://your.gitlab.com/project/-/pipelines/54004"}
 		pr.FullName = organization + "/" + userHandle
+		rs.EXPECT().
+			GetCombinedStatus(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, s.Config.E2EWebappReponame, gomock.Any(), nil).
+			Times(1).
+			Return(&github.CombinedStatus{
+				State: github.String(statePending),
+			}, nil, nil)
 		rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).Times(1).Return([]*github.RepoStatus{
 			{
 				State:   github.String(stateSuccess),
@@ -182,7 +187,7 @@ func TestHandleE2ETesting(t *testing.T) {
 			&github.PullRequest{
 				Number: &pr.Number,
 				Base: &github.PullRequestBranch{
-					Ref: github.String("master"),
+					Ref: github.String("release-6.0"),
 				},
 			},
 			&github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
@@ -194,6 +199,8 @@ func TestHandleE2ETesting(t *testing.T) {
 		glPS.EXPECT().GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(notSameEnvs0, nil, nil)
 		glPS.EXPECT().GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(notSameEnvs1, nil, nil)
 
+		commentInit := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtOpts, e2eTestMsgOpts, nil))}
+		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentInit).Times(1).Return(nil, nil, nil)
 		glPS.EXPECT().CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
 		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, e2eTestMsgSuccess, p.WebURL))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
@@ -201,42 +208,6 @@ func TestHandleE2ETesting(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("happy trigger from webapp with options", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-
-		const userHandle = "user"
-		const organization = "mattertest"
-		s := Server{
-			Config: &Config{
-				Org:                    organization,
-				E2EGitLabProject:       "qa%2Fcypress",
-				E2EWebappReponame:      "mattermost-webapp",
-				E2EServerReponame:      "mattermost-server",
-				E2EWebappRef:           "e2e-webapp-pr",
-				E2EServerRef:           "e2e-server-pr",
-				E2EDockerRepo:          "mattermost/mm-ee-test",
-				E2EServerStatusContext: "ee/circleci",
-				E2EWebappStatusContext: "ci/circleci: build-docker",
-				E2ETestDeadline:        5 * time.Second,
-				E2EGitHubRateLimitHack: 1 * time.Second,
-			},
-			GithubClient:     &GithubClient{},
-			GitLabCIClientV4: &GitLabClient{},
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
-		defer cancel()
-		is := mocks.NewMockIssuesService(ctrl)
-		rs := mocks.NewMockRepositoriesService(ctrl)
-		prs := mocks.NewMockPullRequestsService(ctrl)
-		glPS := mocks.NewMockPipelinesService(ctrl)
-		s.GithubClient.Issues = is
-		s.GithubClient.Repositories = rs
-		s.GithubClient.PullRequests = prs
-		s.GitLabCIClientV4.Pipelines = glPS
-
-		gCtxInterface := reflect.TypeOf(gitlab.RequestOptionFunc(nil))
-		ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
-
 		commentBody := commandE2ETestAdvanced
 		s.OrgMembers = make([]string, 1)
 		s.OrgMembers[0] = userHandle
@@ -284,19 +255,18 @@ func TestHandleE2ETesting(t *testing.T) {
 		}
 		p := &gitlab.Pipeline{WebURL: "https://your.gitlab.com/project/-/pipelines/54004"}
 		pr.FullName = organization + "/" + userHandle
-		first := rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).Times(1).Return([]*github.RepoStatus{
-			{
-				State:   github.String(stateError),
-				Context: &s.Config.E2EWebappStatusContext,
-			},
-		}, nil, nil)
-		second := rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).Times(1).Return([]*github.RepoStatus{
+		rs.EXPECT().
+			GetCombinedStatus(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, s.Config.E2EWebappReponame, gomock.Any(), nil).
+			Times(1).
+			Return(&github.CombinedStatus{
+				State: github.String(statePending),
+			}, nil, nil)
+		rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).Times(1).Return([]*github.RepoStatus{
 			{
 				State:   github.String(stateSuccess),
 				Context: &s.Config.E2EWebappStatusContext,
 			},
 		}, nil, nil)
-		gomock.InOrder(first, second)
 		rs.EXPECT().GetBranch(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, s.Config.E2EServerReponame, pr.Ref, false).Times(1).Return(
 			nil,
 			&github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}},
@@ -306,7 +276,7 @@ func TestHandleE2ETesting(t *testing.T) {
 			&github.PullRequest{
 				Number: &pr.Number,
 				Base: &github.PullRequestBranch{
-					Ref: github.String("master"),
+					Ref: github.String("release-6.0"),
 				},
 			},
 			&github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
@@ -332,42 +302,6 @@ func TestHandleE2ETesting(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("happy trigger from server", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-
-		const userHandle = "user"
-		const organization = "mattertest"
-		s := Server{
-			Config: &Config{
-				Org:                    organization,
-				E2EGitLabProject:       "qa%2Fcypress",
-				E2EWebappReponame:      "mattermost-webapp",
-				E2EServerReponame:      "mattermost-server",
-				E2EWebappRef:           "e2e-webapp-pr",
-				E2EServerRef:           "e2e-server-pr",
-				E2EDockerRepo:          "mattermost/mm-ee-test",
-				E2EServerStatusContext: "ee/circleci",
-				E2EWebappStatusContext: "ci/circleci: build-docker",
-				E2ETestDeadline:        5 * time.Second,
-				E2EGitHubRateLimitHack: 1 * time.Second,
-			},
-			GithubClient:     &GithubClient{},
-			GitLabCIClientV4: &GitLabClient{},
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
-		defer cancel()
-		is := mocks.NewMockIssuesService(ctrl)
-		rs := mocks.NewMockRepositoriesService(ctrl)
-		prs := mocks.NewMockPullRequestsService(ctrl)
-		glPS := mocks.NewMockPipelinesService(ctrl)
-		s.GithubClient.Issues = is
-		s.GithubClient.Repositories = rs
-		s.GithubClient.PullRequests = prs
-		s.GitLabCIClientV4.Pipelines = glPS
-
-		gCtxInterface := reflect.TypeOf(gitlab.RequestOptionFunc(nil))
-		ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
-
 		commentBody := commandE2ETestBase
 		s.OrgMembers = make([]string, 1)
 		s.OrgMembers[0] = userHandle
@@ -416,252 +350,85 @@ func TestHandleE2ETesting(t *testing.T) {
 		p := &gitlab.Pipeline{WebURL: "https://your.gitlab.com/project/-/pipelines/54004"}
 		pr.FullName = organization + "/" + userHandle
 		rs.EXPECT().
-			ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).
+			GetCombinedStatus(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, s.Config.E2EServerReponame, gomock.Any(), nil).
 			Times(1).
-			Return([]*github.RepoStatus{
-				{
-					State:   github.String(stateSuccess),
-					Context: &s.Config.E2EServerStatusContext,
-				},
+			Return(&github.CombinedStatus{
+				State: github.String(statePending),
 			}, nil, nil)
-		rs.EXPECT().
-			GetBranch(
-				gomock.AssignableToTypeOf(ctxInterface),
-				s.Config.Org,
-				s.Config.E2EWebappReponame,
-				pr.Ref,
-				false,
-			).
-			Times(1).
-			Return(
-				nil,
-				&github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}},
-				errors.New(ghBranchNotFoundError),
-			)
-		prs.EXPECT().
-			Get(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, pr.RepoName, pr.Number).
-			Times(1).
-			Return(
-				&github.PullRequest{
-					Number: &pr.Number,
-					Base: &github.PullRequestBranch{
-						Ref: github.String("master"),
-					},
+		rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).Times(1).Return([]*github.RepoStatus{
+			{
+				State:   github.String(stateSuccess),
+				Context: &s.Config.E2EServerStatusContext,
+			},
+		}, nil, nil)
+		rs.EXPECT().GetBranch(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, s.Config.E2EWebappReponame, pr.Ref, false).Times(1).Return(
+			nil,
+			&github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}},
+			errors.New(ghBranchNotFoundError),
+		)
+		prs.EXPECT().Get(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, pr.RepoName, pr.Number).Times(1).Return(
+			&github.PullRequest{
+				Number: &pr.Number,
+				Base: &github.PullRequestBranch{
+					Ref: github.String("release-6.0"),
 				},
-				&github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
-				nil,
-			)
-		glPS.EXPECT().
-			ListProjectPipelines(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).
-			Times(1).
-			Return(pipsC, nil, nil)
-		glPS.EXPECT().
-			ListProjectPipelines(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).
-			Times(1).
-			Return(pipsP, nil, nil)
-		glPS.EXPECT().
-			ListProjectPipelines(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).
-			Times(1).
-			Return(nil, nil, nil)
-		glPS.EXPECT().
-			GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).
-			Times(1).
-			Return(notSameEnvs0, nil, nil)
-		glPS.EXPECT().
-			GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).
-			Times(1).
-			Return(notSameEnvs1, nil, nil)
+			},
+			&github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+			nil,
+		)
+		glPS.EXPECT().ListProjectPipelines(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(pipsC, nil, nil)
+		glPS.EXPECT().ListProjectPipelines(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(pipsP, nil, nil)
+		glPS.EXPECT().ListProjectPipelines(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(nil, nil, nil)
+		glPS.EXPECT().GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(notSameEnvs0, nil, nil)
+		glPS.EXPECT().GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(notSameEnvs1, nil, nil)
 
 		commentInit := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtOpts, e2eTestMsgOpts, nil))}
-		is.EXPECT().
-			CreateComment(gomock.AssignableToTypeOf(ctxInterface),
-				pr.RepoOwner,
-				pr.RepoName,
-				pr.Number,
-				commentInit,
-			).
-			Times(1).
-			Return(nil, nil, nil)
-		glPS.EXPECT().
-			CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).
-			Times(1).
-			Return(p, nil, nil)
+		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentInit).Times(1).Return(nil, nil, nil)
+		glPS.EXPECT().CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
 		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, e2eTestMsgSuccess, p.WebURL))}
-		is.EXPECT().
-			CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).
-			Times(1).
-			Return(nil, nil, nil)
+		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.NoError(t, err)
 	})
 	t.Run("random user", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-
-		const userHandle = "user"
-		const organization = "mattertest"
-		s := Server{
-			Config: &Config{
-				Org:                    organization,
-				E2EGitLabProject:       "qa%2Fcypress",
-				E2EWebappReponame:      "mattermost-webapp",
-				E2EServerReponame:      "mattermost-server",
-				E2EWebappRef:           "e2e-webapp-pr",
-				E2EServerRef:           "e2e-server-pr",
-				E2EDockerRepo:          "mattermost/mm-ee-test",
-				E2EServerStatusContext: "ee/circleci",
-				E2EWebappStatusContext: "ci/circleci: build-docker",
-				E2ETestDeadline:        5 * time.Second,
-				E2EGitHubRateLimitHack: 1 * time.Second,
-			},
-			GithubClient:     &GithubClient{},
-			GitLabCIClientV4: &GitLabClient{},
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
-		defer cancel()
-		is := mocks.NewMockIssuesService(ctrl)
-		rs := mocks.NewMockRepositoriesService(ctrl)
-		prs := mocks.NewMockPullRequestsService(ctrl)
-		glPS := mocks.NewMockPipelinesService(ctrl)
-		s.GithubClient.Issues = is
-		s.GithubClient.Repositories = rs
-		s.GithubClient.PullRequests = prs
-		s.GitLabCIClientV4.Pipelines = glPS
-
-		ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
-
-		s.OrgMembers = make([]string, 1)
-		s.OrgMembers[0] = userHandle
+		*msg = e2eTestMsgCommenterPermission
 		commentBody := commandE2ETestBase
 		pr := &model.PullRequest{
 			RepoOwner: userHandle,
 			RepoName:  s.Config.E2EWebappReponame,
-			Number:    prNumber,
-			Ref:       eBranch,
-			Sha:       eSHA,
+			Number:    123,
 		}
-		is.EXPECT().
-			CreateComment(
-				gomock.AssignableToTypeOf(ctxInterface),
-				pr.RepoOwner,
-				pr.RepoName,
-				pr.Number,
-				&github.IssueComment{Body: github.String(e2eTestMsgCommenterPermission)},
-			).
-			Times(1).
-			Return(nil, nil, nil)
+		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, comment).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, "someone", pr, commentBody)
 		require.Error(t, err)
 		require.IsType(t, &E2ETestError{}, err)
-		require.Equal(t, err.(*E2ETestError).source, e2eTestMsgCommenterPermission)
+		require.Equal(t, err.(*E2ETestError).source, *msg)
 	})
 	t.Run("pr not ready", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-
-		const userHandle = "user"
-		const organization = "mattertest"
-		s := Server{
-			Config: &Config{
-				Org:                    organization,
-				E2EGitLabProject:       "qa%2Fcypress",
-				E2EWebappReponame:      "mattermost-webapp",
-				E2EServerReponame:      "mattermost-server",
-				E2EWebappRef:           "e2e-webapp-pr",
-				E2EServerRef:           "e2e-server-pr",
-				E2EDockerRepo:          "mattermost/mm-ee-test",
-				E2EServerStatusContext: "ee/circleci",
-				E2EWebappStatusContext: "ci/circleci: build-docker",
-				E2ETestDeadline:        5 * time.Second,
-				E2EGitHubRateLimitHack: 1 * time.Second,
-			},
-			GithubClient:     &GithubClient{},
-			GitLabCIClientV4: &GitLabClient{},
-		}
-
-		is := mocks.NewMockIssuesService(ctrl)
-		rs := mocks.NewMockRepositoriesService(ctrl)
-		prs := mocks.NewMockPullRequestsService(ctrl)
-		glPS := mocks.NewMockPipelinesService(ctrl)
-		s.GithubClient.Issues = is
-		s.GithubClient.Repositories = rs
-		s.GithubClient.PullRequests = prs
-		s.GitLabCIClientV4.Pipelines = glPS
-
-		ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
-
+		*msg = e2eTestMsgCIFailing
 		commentBody := commandE2ETestBase
 		s.OrgMembers = make([]string, 1)
 		s.OrgMembers[0] = userHandle
 		pr := &model.PullRequest{
 			RepoOwner: userHandle,
 			RepoName:  s.Config.E2EWebappReponame,
-			Number:    prNumber,
-			Ref:       eBranch,
-			Sha:       eSHA,
+			Number:    123,
 		}
 		pr.FullName = organization + "/" + userHandle
 		rs.EXPECT().
-			ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).
-			Times(5).
-			Return([]*github.RepoStatus{
-				{
-					State:   github.String(stateError),
-					Context: &s.Config.E2EWebappStatusContext,
-				},
-			}, nil, nil)
-		is.EXPECT().
-			CreateComment(
-				gomock.AssignableToTypeOf(ctxInterface),
-				pr.RepoOwner,
-				pr.RepoName,
-				pr.Number,
-				&github.IssueComment{Body: github.String(e2eTestMsgCIFailing)},
-			).
+			GetCombinedStatus(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, s.Config.E2EWebappReponame, gomock.Any(), nil).
 			Times(1).
-			Return(nil, nil, nil)
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(s.Config.E2ETestDeadline))
-		defer cancel()
+			Return(&github.CombinedStatus{
+				State: github.String(stateError), // statePending can run e2e-test (block-pr-merge.go)
+			}, nil, nil)
+		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, comment).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.Error(t, err)
 		require.IsType(t, &E2ETestError{}, err)
-		require.Equal(t, err.(*E2ETestError).source, e2eTestMsgCIFailing)
+		require.Equal(t, err.(*E2ETestError).source, *msg)
 	})
 	t.Run("webapp do not trigger with same envs", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-
-		const userHandle = "user"
-		const organization = "mattertest"
-		s := Server{
-			Config: &Config{
-				Org:                    organization,
-				E2EGitLabProject:       "qa%2Fcypress",
-				E2EWebappReponame:      "mattermost-webapp",
-				E2EServerReponame:      "mattermost-server",
-				E2EWebappRef:           "e2e-webapp-pr",
-				E2EServerRef:           "e2e-server-pr",
-				E2EDockerRepo:          "mattermost/mm-ee-test",
-				E2EServerStatusContext: "ee/circleci",
-				E2EWebappStatusContext: "ci/circleci: build-docker",
-				E2ETestDeadline:        5 * time.Second,
-				E2EGitHubRateLimitHack: 1 * time.Second,
-			},
-			GithubClient:     &GithubClient{},
-			GitLabCIClientV4: &GitLabClient{},
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
-		defer cancel()
-		is := mocks.NewMockIssuesService(ctrl)
-		rs := mocks.NewMockRepositoriesService(ctrl)
-		prs := mocks.NewMockPullRequestsService(ctrl)
-		glPS := mocks.NewMockPipelinesService(ctrl)
-		s.GithubClient.Issues = is
-		s.GithubClient.Repositories = rs
-		s.GithubClient.PullRequests = prs
-		s.GitLabCIClientV4.Pipelines = glPS
-
-		gCtxInterface := reflect.TypeOf(gitlab.RequestOptionFunc(nil))
-		ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
+		*msg = e2eTestMsgSameEnvs
 		eEnvKey0 := "MM_ENV"
 		eEnvValue0 := "MM_FEATUREFLAGS_GLOBALHEADER=true,MM_OTHER_FLAG=true"
 		eEnvKey1 := "INCLUDE_FILE"
@@ -792,6 +559,12 @@ func TestHandleE2ETesting(t *testing.T) {
 			},
 		}
 		pr.FullName = organization + "/" + userHandle
+		rs.EXPECT().
+			GetCombinedStatus(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, s.Config.E2EWebappReponame, gomock.Any(), nil).
+			Times(1).
+			Return(&github.CombinedStatus{
+				State: github.String(statePending),
+			}, nil, nil)
 		rs.EXPECT().ListStatuses(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Sha, nil).Times(1).Return([]*github.RepoStatus{
 			{
 				State:   github.String(stateSuccess),
@@ -807,7 +580,7 @@ func TestHandleE2ETesting(t *testing.T) {
 			&github.PullRequest{
 				Number: &pr.Number,
 				Base: &github.PullRequestBranch{
-					Ref: github.String("master"),
+					Ref: github.String("release-6.0"),
 				},
 			},
 			&github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
@@ -821,23 +594,11 @@ func TestHandleE2ETesting(t *testing.T) {
 		glPS.EXPECT().GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(NotSameEnvs2, nil, nil)
 		glPS.EXPECT().GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(sameEnvs, nil, nil)
 
-		is.EXPECT().CreateComment(
-			gomock.AssignableToTypeOf(ctxInterface),
-			pr.RepoOwner,
-			pr.RepoName,
-			pr.Number,
-			&github.IssueComment{Body: github.String("Triggering e2e testing with options:\n```&map[EXCLUDE_FILE:something_to_exclude_spec.js INCLUDE_FILE:new_message_spec.js MM_ENV:MM_FEATUREFLAGS_GLOBALHEADER=true,MM_OTHER_FLAG=true]```")},
-		).Times(1).Return(nil, nil, nil)
-		is.EXPECT().CreateComment(
-			gomock.AssignableToTypeOf(ctxInterface),
-			pr.RepoOwner,
-			pr.RepoName,
-			pr.Number,
-			&github.IssueComment{Body: github.String(e2eTestMsgSameEnvs)},
-		).Times(1).Return(nil, nil, nil)
+		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, gomock.Any()).Times(1).Return(nil, nil, nil)
+		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, comment).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.Error(t, err)
 		require.IsType(t, &E2ETestError{}, err)
-		require.Equal(t, err.(*E2ETestError).source, e2eTestMsgSameEnvs)
+		require.Equal(t, err.(*E2ETestError).source, *msg)
 	})
 }

--- a/server/github.go
+++ b/server/github.go
@@ -331,15 +331,15 @@ func (s *Server) createRepoStatus(ctx context.Context, pr *model.PullRequest, st
 	return nil
 }
 
-func (s *Server) waitForStatus(ctx context.Context, pr *model.PullRequest, statusContext string, statusState string, interval time.Duration) error {
-	ticker := time.NewTicker(interval)
+func (s *Server) waitForStatus(ctx context.Context, pr *model.PullRequest, statusContext string, statusState string, t time.Duration) error {
+	ticker := time.NewTicker(t)
 	for {
 		select {
 		case <-ctx.Done():
 			ticker.Stop()
-			return ctx.Err()
-		case t := <-ticker.C:
-			mlog.Debug("Waiting for status", mlog.Int("pr", pr.Number), mlog.String("context", statusContext), mlog.String("ticker", t.String()))
+			return errors.New("timed out waiting for status " + statusContext)
+		case <-ticker.C:
+			mlog.Debug("Waiting for status", mlog.Int("pr", pr.Number), mlog.String("context", statusContext))
 			statuses, _, err := s.GithubClient.Repositories.ListStatuses(ctx, pr.RepoOwner, pr.RepoName, pr.Sha, nil)
 			if err != nil {
 				return err
@@ -348,7 +348,6 @@ func (s *Server) waitForStatus(ctx context.Context, pr *model.PullRequest, statu
 			hasStatus := false
 			for _, status := range statuses {
 				if *status.Context == statusContext && *status.State == statusState {
-					mlog.Debug("Got successfully context status", mlog.String("context", statusContext), mlog.String("state", statusState), mlog.String("ticker", t.String()))
 					hasStatus = true
 				}
 			}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
--> This is a partial revert, fixing the e2e-spam, but not using the specific GitHub status context to only require docker build steps to pass. The whole CI pipeline still needs to pass. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

