### PR TITLE
server/fast_forward: add --dry-run flag to fast-forward process

### DIFF
--- a/server/fast_forward_test.go
+++ b/server/fast_forward_test.go
@@ -182,7 +182,6 @@ func TestPerformFastForwardProcess(t *testing.T) {
 		}, nil, nil)
 
 		ctx := context.Background()
-		fmt.Println("1")
 		res, err := s.performFastForwardProcess(ctx, issue, "/cloud-ff --dry-run", member)
 		require.NoError(t, err)
 		require.Len(t, res.Backup, 1)


### PR DESCRIPTION


#### Summary
Adds a `--dry-run` flag to the /cloud-ff command.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43738

