### PR TITLE
Fix automatic translation PR assignment

### DIFF
--- a/server/translations.go
+++ b/server/translations.go
@@ -49,7 +49,7 @@ func (s *Server) removeTranslationLabel(ctx context.Context, pr *model.PullReque
 }
 
 func (s *Server) isTranslationPr(pr *model.PullRequest) bool {
-	return pr.Username != s.Config.TranslationsBot
+	return pr.Username == s.Config.TranslationsBot
 }
 
 func (s *Server) hasTranslationMergeLabel(labels []string) bool {


### PR DESCRIPTION
#### Summary
This PR fixes automatic label assignment for non-translation-PRs.
We added mattermod to add a label `Do Not Merge/Mattermod` for translation prs. Cause of negative check it assings that label to every other PR.

Issue can be seen at this PR label history.