### PR TITLE
E2E: Fix context deadline exceeded when calling goroutine to trigger …

### DIFF
--- a/server/e2e_test_from_label.go
+++ b/server/e2e_test_from_label.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-github/v39/github"
 	"github.com/mattermost/mattermost-mattermod/model"
@@ -28,7 +29,9 @@ type E2ETestFromLabelError struct {
 	source string
 }
 
-func (s *Server) triggerE2ETestFromLabel(ctx context.Context, pr *model.PullRequest) {
+func (s *Server) triggerE2ETestFromLabel(pr *model.PullRequest) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout*time.Second)
+	defer cancel()
 	var e2eTestFromLabelErr *E2ETestFromLabelError
 	defer func() {
 		if e2eTestFromLabelErr != nil {

--- a/server/pull_request_handler.go
+++ b/server/pull_request_handler.go
@@ -132,7 +132,7 @@ func (s *Server) pullRequestEventHandler(w http.ResponseWriter, r *http.Request)
 
 		if (pr.RepoName == s.Config.E2EServerReponame || pr.RepoName == s.Config.E2EWebappReponame) && contains(s.Config.E2ETriggerLabel, *event.Label.Name) {
 			mlog.Info("Label to run e2e tests", mlog.Int("pr", event.PRNumber), mlog.String("repo", pr.RepoName), mlog.String("label", *event.Label.Name))
-			go s.triggerE2ETestFromLabel(ctx, pr)
+			go s.triggerE2ETestFromLabel(pr)
 		}
 
 		if pr.RepoName == s.Config.EnterpriseTriggerReponame &&


### PR DESCRIPTION
…e2e test from label.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
--> Somehow I missed that one. Makes sense. 
```
{\"level\":\"error\",\"ts\":redacted,\"caller\":\"server/e2e_test_from_label.go:43\",\"msg\":\"Error getting reviews for the PR\",\"pr\":redacted,\"repo\":\"mattermost-webapp\",\"error\":\"context canceled\"}
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

