### PR TITLE
Fix master breakage

### DIFF
--- a/config/config-mattermod.default.json
+++ b/config/config-mattermod.default.json
@@ -112,6 +112,7 @@
     "LogSettings": {
         "EnableConsole": true,
         "ConsoleLevel": "DEBUG",
+        "EnableColor": false,
         "ConsoleJson": true,
         "EnableFile": true,
         "FileLevel": "INFO",

--- a/server/config.go
+++ b/server/config.go
@@ -136,6 +136,7 @@ type Config struct {
 		FileLevel     string
 		FileLocation  string
 		EnableConsole bool
+		EnableColor   bool
 		ConsoleJSON   bool
 		EnableFile    bool
 		FileJSON      bool

--- a/server/server.go
+++ b/server/server.go
@@ -373,6 +373,7 @@ func SetupLogging(c *Config) error {
 		ConsoleJson:   model.NewBool(c.LogSettings.ConsoleJSON),
 		ConsoleLevel:  model.NewString(strings.ToLower(c.LogSettings.ConsoleLevel)),
 		EnableFile:    model.NewBool(c.LogSettings.EnableFile),
+		EnableColor:   model.NewBool(c.LogSettings.EnableColor),
 		FileJson:      model.NewBool(c.LogSettings.FileJSON),
 		FileLevel:     model.NewString(strings.ToLower(c.LogSettings.FileLevel)),
 		FileLocation:  model.NewString(GetLogFileLocation(c.LogSettings.FileLocation)),


### PR DESCRIPTION
We need to set the value of EnableColor field.
Otherwise it leads to a nil pointer dereference
when constructing the logger.
