### PR TITLE
MM-43288: Cleanup old cloud branches

### DIFF
--- a/cmd/jobserver/main.go
+++ b/cmd/jobserver/main.go
@@ -64,6 +64,12 @@ func main() {
 		mlog.Error("failed adding CleanOutdatedPRs cron", mlog.Err(err))
 	}
 
+	// Run once a month
+	_, err = c.AddFunc("0 12 1 * *", s.CleanOutdatedCloudBranches)
+	if err != nil {
+		mlog.Error("failed adding CleanOutdatedCloudBranches cron", mlog.Err(err))
+	}
+
 	_, err = c.AddFunc("@every 30m", func() {
 		err2 := s.AutoMergePR()
 		if err2 != nil {

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -67,7 +67,7 @@ func (m *Server) Start() {
 
 	go func() {
 		mlog.Info("Metrics and profiling server started", mlog.String("port", m.port))
-		if err := m.server.ListenAndServe(); err != nil {
+		if err := m.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			mlog.Error("Error trying to start the metrics server", mlog.Err(err))
 			return
 		}

--- a/server/github_client.go
+++ b/server/github_client.go
@@ -62,6 +62,7 @@ type RepositoriesService interface {
 	CreateStatus(ctx context.Context, owner, repo, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error)
 	Get(ctx context.Context, owner, repo string) (*github.Repository, *github.Response, error)
 	GetBranch(ctx context.Context, owner, repo, branch string, followRedirects bool) (*github.Branch, *github.Response, error)
+	ListBranches(ctx context.Context, owner string, repo string, opts *github.BranchListOptions) ([]*github.Branch, *github.Response, error)
 	GetCombinedStatus(ctx context.Context, owner, repo, ref string, opts *github.ListOptions) (*github.CombinedStatus, *github.Response, error)
 	ListTeams(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.Team, *github.Response, error)
 	ListStatuses(ctx context.Context, owner, repo, ref string, opts *github.ListOptions) ([]*github.RepoStatus, *github.Response, error)

--- a/server/mocks/github_client.go
+++ b/server/mocks/github_client.go
@@ -659,6 +659,22 @@ func (mr *MockRepositoriesServiceMockRecorder) GetCombinedStatus(ctx, owner, rep
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCombinedStatus", reflect.TypeOf((*MockRepositoriesService)(nil).GetCombinedStatus), ctx, owner, repo, ref, opts)
 }
 
+// ListBranches mocks base method.
+func (m *MockRepositoriesService) ListBranches(ctx context.Context, owner, repo string, opts *github.BranchListOptions) ([]*github.Branch, *github.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBranches", ctx, owner, repo, opts)
+	ret0, _ := ret[0].([]*github.Branch)
+	ret1, _ := ret[1].(*github.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListBranches indicates an expected call of ListBranches.
+func (mr *MockRepositoriesServiceMockRecorder) ListBranches(ctx, owner, repo, opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBranches", reflect.TypeOf((*MockRepositoriesService)(nil).ListBranches), ctx, owner, repo, opts)
+}
+
 // ListStatuses mocks base method.
 func (m *MockRepositoriesService) ListStatuses(ctx context.Context, owner, repo, ref string, opts *github.ListOptions) ([]*github.RepoStatus, *github.Response, error) {
 	m.ctrl.T.Helper()

--- a/server/server.go
+++ b/server/server.go
@@ -224,9 +224,6 @@ func (s *Server) Tick() {
 				prListOpts.Page = resp.NextPage
 				continue
 			}
-			if resp.NextPage == 0 {
-				break
-			}
 			prListOpts.Page = resp.NextPage
 			time.Sleep(200 * time.Millisecond)
 
@@ -244,6 +241,9 @@ func (s *Server) Tick() {
 				} else if changed {
 					mlog.Info("pr has changes", mlog.Int("pr", pullRequest.Number))
 				}
+			}
+			if resp.NextPage == 0 {
+				break
 			}
 		}
 
@@ -265,9 +265,6 @@ func (s *Server) Tick() {
 				issueListOpts.Page = resp.NextPage
 				continue
 			}
-			if resp.NextPage == 0 {
-				break
-			}
 			issueListOpts.Page = resp.NextPage
 
 			time.Sleep(200 * time.Millisecond)
@@ -288,6 +285,9 @@ func (s *Server) Tick() {
 				if err := s.checkIssueForChanges(ctx, issue); err != nil {
 					mlog.Error("could not check issue for changes", mlog.Err(err))
 				}
+			}
+			if resp.NextPage == 0 {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
We create a cron job that will once a month
and clean up old branches.

Also fix an unrelated bug with resp.NextPage.
We need to check for NextPage == 0, _after_
processing the current batch, not before. This
skips the last batch of items.

https://mattermost.atlassian.net/browse/MM-43288
