### PR TITLE
Fix broken cherry-pick functionaliy for label `CherryPick/Approved`

### DIFF
--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -26,6 +26,7 @@ import (
 const (
 	cherryPickScheduledMsg = "Cherry pick is scheduled."
 	tooManyCherryPickMsg   = "There are too many cherry picking requests. Please do this manually or try again later."
+	milestoneCloud         = "cloud"
 )
 
 type cherryPickRequest struct {
@@ -181,7 +182,7 @@ func getMilestone(title string) string {
 	milestone := strings.TrimSpace(title)
 	milestone = strings.Trim(milestone, "v")
 	milestone = strings.TrimSuffix(milestone, ".0")
-	if title != "cloud" {
+	if title != milestoneCloud {
 		milestone = fmt.Sprintf("release-%s", milestone)
 	}
 	return milestone

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -181,7 +181,9 @@ func getMilestone(title string) string {
 	milestone := strings.TrimSpace(title)
 	milestone = strings.Trim(milestone, "v")
 	milestone = strings.TrimSuffix(milestone, ".0")
-	milestone = fmt.Sprintf("release-%s", milestone)
+	if title != "cloud" {
+		milestone = fmt.Sprintf("release-%s", milestone)
+	}
 	return milestone
 }
 


### PR DESCRIPTION
#### Summary
The `getMilestone` function adds a prefix to every mileston and generates the target
branch with `release-*`. The `cloud` branch hasn't any prefix so that's why it fails
when we try to use the label cherry pick functionality.

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/CLD-4001
