### PR TITLE
Migrate from deprecated `io/ioutil` to `io`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,7 +59,12 @@ issues:
 
   exclude-rules:
     - linters:
-      - goconst
+        - gofmt
+        - goimports
+      # Ignore this file as it append generate tags and golangci-lint fails
+      path: assets.go
+    - linters:
+        - goconst
       # Ignore warnings trying to change variables to constants.
       # We can't do that because we are taking the address of those variables.
       path: "issue_handler_test.go"

--- a/server/cla.go
+++ b/server/cla.go
@@ -6,7 +6,7 @@ package server
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -83,7 +83,7 @@ func (s *Server) getCSV(ctx context.Context) ([]byte, error) {
 	}
 	defer closeBody(r)
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		s.logToMattermost(ctx, "unable to read CLA google csv file Error: ```"+err.Error()+"```")
 		return nil, err

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -6,7 +6,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -105,13 +105,13 @@ func (t *MetricsTransport) processGithubMetrics(req *http.Request, resp *http.Re
 		// Read body to check if there is an error message,
 		// then close it and re-assigning the body again for the
 		// next layer so it could read the body without problem
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
 		resp.Body.Close()
 		defer func() {
-			resp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+			resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}()
 
 		err = json.Unmarshal(bodyBytes, &msg)

--- a/server/review.go
+++ b/server/review.go
@@ -6,7 +6,7 @@ package server
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -91,7 +91,7 @@ func getRawDiff(ctx context.Context, url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -314,7 +313,7 @@ func (s *Server) githubEvent(w http.ResponseWriter, r *http.Request) {
 		}
 		mlog.Info("ping event", mlog.Int64("HookID", pingEvent.GetHookID()))
 	case "issues":
-		buf, err := ioutil.ReadAll(r.Body)
+		buf, err := io.ReadAll(r.Body)
 		if err != nil {
 			mlog.Error("Failed to read body", mlog.Err(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -333,7 +332,7 @@ func (s *Server) githubEvent(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
 		// An issue can be both an issue or a PR. So we need to differentiate between the two.
 		if event.Issue.IsPullRequest() {
 			mlog.Info("A PR event is found from an issue. Updating DB.", mlog.String("link", event.Issue.GetPullRequestLinks().GetHTMLURL()))
@@ -402,7 +401,7 @@ func SetupLogging(c *Config) error {
 
 func closeBody(r *http.Response) {
 	if r.Body != nil {
-		_, _ = io.Copy(ioutil.Discard, r.Body)
+		_, _ = io.Copy(io.Discard, r.Body)
 		_ = r.Body.Close()
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6,7 +6,6 @@ package server
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -64,7 +63,7 @@ func TestWithRecovery(t *testing.T) {
 	resp := w.Result()
 	if resp.Body != nil {
 		defer resp.Body.Close()
-		_, err := io.Copy(ioutil.Discard, resp.Body)
+		_, err := io.Copy(io.Discard, resp.Body)
 		require.NoError(t, err)
 	}
 }

--- a/server/validate_signature.go
+++ b/server/validate_signature.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -27,14 +27,14 @@ func (s *Server) withValidation(next http.Handler) http.Handler {
 			return
 		}
 
-		buf, err := ioutil.ReadAll(r.Body)
+		buf, err := io.ReadAll(r.Body)
 		if err != nil {
 			mlog.Error("Failed to read body", mlog.Err(err))
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		r.Body.Close()
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
 
 		err = validateSignature(receivedHash, buf, s.Config.GitHubWebhookSecret)
 		if err != nil {


### PR DESCRIPTION
#### Summary
After Go 1.16 the `io/ioutil` has been deprecated and the Golang CI lint is failing.
Replaced all the references to make CI back to green.

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/CLD-4064
