### PR TITLE
E2E: Add link to test dashboard

### DIFF
--- a/config/config-mattermod.default.json
+++ b/config/config-mattermod.default.json
@@ -67,6 +67,7 @@
     "E2EWebappStatusContext": "",
     "E2EServerStatusContext": "",
     "E2ETriggerLabel": ["3: QA Review", "QA Deferred", "Run E2E Testing"],
+    "TestAutomationDashboardURL": "",
 
     "EnterpriseReponame": "",
     "EnterpriseTriggerReponame": "",

--- a/config/config-mattermod.default.json
+++ b/config/config-mattermod.default.json
@@ -67,7 +67,7 @@
     "E2EWebappStatusContext": "",
     "E2EServerStatusContext": "",
     "E2ETriggerLabel": ["3: QA Review", "QA Deferred", "Run E2E Testing"],
-    "TestAutomationDashboardURL": "",
+    "E2ETestAutomationDashboardURL": "",
 
     "EnterpriseReponame": "",
     "EnterpriseTriggerReponame": "",

--- a/server/config.go
+++ b/server/config.go
@@ -89,15 +89,16 @@ type Config struct {
 	BuildAppBranchPrefix  string
 	BuildAppJobs          []*BuildAppJob
 
-	E2EDockerRepo          string
-	E2EGitLabProject       string
-	E2EWebappRef           string
-	E2EServerRef           string
-	E2EWebappReponame      string
-	E2EServerReponame      string
-	E2EWebappStatusContext string
-	E2EServerStatusContext string
-	E2ETriggerLabel        []string
+	E2EDockerRepo              string
+	E2EGitLabProject           string
+	E2EWebappRef               string
+	E2EServerRef               string
+	E2EWebappReponame          string
+	E2EServerReponame          string
+	E2EWebappStatusContext     string
+	E2EServerStatusContext     string
+	E2ETriggerLabel            []string
+	TestAutomationDashboardURL string
 
 	EnterpriseReponame            string
 	EnterpriseTriggerReponame     string

--- a/server/config.go
+++ b/server/config.go
@@ -89,16 +89,16 @@ type Config struct {
 	BuildAppBranchPrefix  string
 	BuildAppJobs          []*BuildAppJob
 
-	E2EDockerRepo              string
-	E2EGitLabProject           string
-	E2EWebappRef               string
-	E2EServerRef               string
-	E2EWebappReponame          string
-	E2EServerReponame          string
-	E2EWebappStatusContext     string
-	E2EServerStatusContext     string
-	E2ETriggerLabel            []string
-	TestAutomationDashboardURL string
+	E2EDockerRepo                 string
+	E2EGitLabProject              string
+	E2EWebappRef                  string
+	E2EServerRef                  string
+	E2EWebappReponame             string
+	E2EServerReponame             string
+	E2EWebappStatusContext        string
+	E2EServerStatusContext        string
+	E2ETriggerLabel               []string
+	E2ETestAutomationDashboardURL string
 
 	EnterpriseReponame            string
 	EnterpriseTriggerReponame     string

--- a/server/e2e_test_command.go
+++ b/server/e2e_test_command.go
@@ -21,10 +21,9 @@ const (
 	e2eTestMsgCompanionBranch     = "Failed to locate companion branch."
 	e2eTestMsgSameEnvs            = "A pipeline with the same environment variables is already running. \n Please cancel it first with /e2e-cancel, or specify different environment variables."
 
-	e2eTestMsgOpts    = "Triggering e2e testing with options:"
+	e2eTestMsgOpts    = "Triggering E2E testing with options:"
 	e2eTestFmtOpts    = "%v\n```%v```"
-	e2eTestMsgSuccess = "Successfully triggered e2e testing!"
-	e2eTestFmtSuccess = "%v\n%v"
+	e2eTestFmtSuccess = "Successfully triggered E2E testing!\n[GitLab pipeline](%v) | [Test dashboard](%v/cycle/%v)"
 )
 
 func (e *E2ETestError) Error() string {
@@ -115,12 +114,12 @@ func (s *Server) handleE2ETest(ctx context.Context, commenter string, pr *model.
 		return e2eTestErr
 	}
 
-	url, err := s.triggerE2EGitLabPipeline(ctx, info)
+	pip, err := s.triggerE2EGitLabPipeline(ctx, info)
 	if err != nil {
 		e2eTestErr = &E2ETestError{source: e2eTestMsgTrigger}
 		return e2eTestErr
 	}
-	endMsg := fmt.Sprintf(e2eTestFmtSuccess, e2eTestMsgSuccess, url)
+	endMsg := fmt.Sprintf(e2eTestFmtSuccess, pip.WebURL, s.Config.TestAutomationDashboardURL, pip.ID)
 	if cErr := s.sendGitHubComment(ctx, prRepoOwner, prRepoName, prNumber, endMsg); cErr != nil {
 		mlog.Warn("Error while commenting", mlog.Err(cErr))
 	}

--- a/server/e2e_test_command.go
+++ b/server/e2e_test_command.go
@@ -119,7 +119,7 @@ func (s *Server) handleE2ETest(ctx context.Context, commenter string, pr *model.
 		e2eTestErr = &E2ETestError{source: e2eTestMsgTrigger}
 		return e2eTestErr
 	}
-	endMsg := fmt.Sprintf(e2eTestFmtSuccess, pip.WebURL, s.Config.TestAutomationDashboardURL, pip.ID)
+	endMsg := fmt.Sprintf(e2eTestFmtSuccess, pip.WebURL, s.Config.E2ETestAutomationDashboardURL, pip.ID)
 	if cErr := s.sendGitHubComment(ctx, prRepoOwner, prRepoName, prNumber, endMsg); cErr != nil {
 		mlog.Warn("Error while commenting", mlog.Err(cErr))
 	}

--- a/server/e2e_test_command_test.go
+++ b/server/e2e_test_command_test.go
@@ -222,7 +222,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		glPS.EXPECT().GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(notSameEnvs1, nil, nil)
 
 		glPS.EXPECT().CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
-		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, e2eTestMsgSuccess, p.WebURL))}
+		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.TestAutomationDashboardURL, p.ID))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.NoError(t, err)
@@ -335,7 +335,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		commentInit := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtOpts, e2eTestMsgOpts, opts))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentInit).Times(1).Return(nil, nil, nil)
 		glPS.EXPECT().CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
-		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, e2eTestMsgSuccess, p.WebURL))}
+		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.TestAutomationDashboardURL, p.ID))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.NoError(t, err)
@@ -462,7 +462,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		commentInit := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtOpts, e2eTestMsgOpts, opts))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentInit).Times(1).Return(nil, nil, nil)
 		glPS.EXPECT().CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
-		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, e2eTestMsgSuccess, p.WebURL))}
+		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.TestAutomationDashboardURL, p.ID))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.NoError(t, err)
@@ -570,7 +570,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		glPS.EXPECT().GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(notSameEnvs1, nil, nil)
 
 		glPS.EXPECT().CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
-		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, e2eTestMsgSuccess, p.WebURL))}
+		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.TestAutomationDashboardURL, p.ID))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.NoError(t, err)

--- a/server/e2e_test_command_test.go
+++ b/server/e2e_test_command_test.go
@@ -222,7 +222,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		glPS.EXPECT().GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(notSameEnvs1, nil, nil)
 
 		glPS.EXPECT().CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
-		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.TestAutomationDashboardURL, p.ID))}
+		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.E2ETestAutomationDashboardURL, p.ID))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.NoError(t, err)
@@ -335,7 +335,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		commentInit := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtOpts, e2eTestMsgOpts, opts))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentInit).Times(1).Return(nil, nil, nil)
 		glPS.EXPECT().CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
-		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.TestAutomationDashboardURL, p.ID))}
+		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.E2ETestAutomationDashboardURL, p.ID))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.NoError(t, err)
@@ -462,7 +462,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		commentInit := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtOpts, e2eTestMsgOpts, opts))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentInit).Times(1).Return(nil, nil, nil)
 		glPS.EXPECT().CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
-		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.TestAutomationDashboardURL, p.ID))}
+		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.E2ETestAutomationDashboardURL, p.ID))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.NoError(t, err)
@@ -570,7 +570,7 @@ func TestHandleE2ETesting(t *testing.T) {
 		glPS.EXPECT().GetPipelineVariables(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(notSameEnvs1, nil, nil)
 
 		glPS.EXPECT().CreatePipeline(s.Config.E2EGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
-		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.TestAutomationDashboardURL, p.ID))}
+		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestFmtSuccess, p.WebURL, s.Config.E2ETestAutomationDashboardURL, p.ID))}
 		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
 		err := s.handleE2ETest(ctx, userHandle, pr, commentBody)
 		require.NoError(t, err)

--- a/server/gitlab.go
+++ b/server/gitlab.go
@@ -44,7 +44,7 @@ type PipelinesService interface {
 	ListProjectPipelines(pid interface{}, opt *gitlab.ListProjectPipelinesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.PipelineInfo, *gitlab.Response, error)
 }
 
-func (s *Server) triggerE2EGitLabPipeline(ctx context.Context, info *E2ETestTriggerInfo) (string, error) {
+func (s *Server) triggerE2EGitLabPipeline(ctx context.Context, info *E2ETestTriggerInfo) (*gitlab.Pipeline, error) {
 	defaultEnvs := []*gitlab.PipelineVariable{
 		{
 			Key:          envKeyRefMattermostServer,
@@ -87,11 +87,8 @@ func (s *Server) triggerE2EGitLabPipeline(ctx context.Context, info *E2ETestTrig
 		Variables: append(defaultEnvs, customEnvs...),
 	}
 	pip, _, err := s.GitLabCIClientV4.Pipelines.CreatePipeline(s.Config.E2EGitLabProject, createOpts, gitlab.WithContext(ctx))
-	if err != nil {
-		return "", err
-	}
 
-	return pip.WebURL, nil
+	return pip, err
 }
 
 func (s *Server) checkForPipelinesWithSameEnvs(ctx context.Context, info *E2ETestTriggerInfo) (bool, error) {


### PR DESCRIPTION
#### Summary
Added link to Test Dashboard which now supports `https://automation-dashboard.vercel.app/cycle/<pipeline_id>`, ex. `https://automation-dashboard.vercel.app/cycle/266131`. See related changes in the dashboard [here](https://github.com/saturninoabril/automation-dashboard/commit/249f0b58db98a33d59593bb43f9f92c74bc83b1a#diff-6aad13058d521d590690e9502805c3238ad0c08a06d9cd08e66dd2298828f101R1-R15).

Once triggered, it will post a comment like the following:
```markdown
Successfully triggered E2E testing!
[GitLab pipeline](https://git.internal.mattermost.com/qa/cypress-ui-automation/-/pipelines/266131) | [Test dashboard](https://automation-dashboard.vercel.app/cycle/266131)
```

This PR adds a config setting of `TestAutomationDashboardURL`. On deployment, it should have a value of `https://automation-dashboard.vercel.app`.
