### PR TITLE
Add desktop e2e test command

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -100,8 +100,13 @@ type Config struct {
 	E2ETriggerLabel               []string
 	E2ETestAutomationDashboardURL string
 
-	E2EMobileCoreReponame  string
-	E2EMobileGitLabProject string
+	E2EMobileCoreReponame          string
+	E2EMobileGitLabProject         string
+	E2EMobileGitLabProjectRefForPR string
+
+	E2EDesktopCoreReponame          string
+	E2EDesktopGitLabProject         string
+	E2EDesktopGitLabProjectRefForPR string
 
 	EnterpriseReponame            string
 	EnterpriseTriggerReponame     string

--- a/server/e2e_test_desktop_command.go
+++ b/server/e2e_test_desktop_command.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mattermost/mattermost-mattermod/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+)
+
+const (
+	e2eTestDesktopMsgCommenterPermission = "You don't have permissions to trigger this command.\n It's only available for organization members."
+	e2eTestDesktopMsgCIFailing           = "The command /e2e-test requires all PR checks to pass."
+	e2eTestDesktopMsgUnknownPRState      = "Failed to check whether PR checks passed. E2E testing isn't triggered. Please retry later."
+	e2eTestDesktopMsgPRInfo              = "Failed to get the PR information required to trigger testing. Please retry later."
+	e2eTestDesktopMsgTrigger             = "Failed to trigger E2E desktop testing pipeline."
+	e2eTestDesktopMsgSuccess             = "Successfully triggered e2e desktop testing!"
+	e2eTestDesktopFmtSuccess             = "%v\n%v"
+)
+
+func (e *E2ETestDesktopError) Error() string {
+	switch e.source {
+	case e2eTestDesktopMsgCommenterPermission:
+		return "commenter does not have permissions for e2e test desktop"
+	case e2eTestDesktopMsgCIFailing:
+		return "PR checks needs to be passing for e2e test desktop"
+	case e2eTestDesktopMsgUnknownPRState:
+		return "unknown PR state for e2e test desktop"
+	case e2eTestDesktopMsgPRInfo:
+		return "could not fetch PR info for e2e test desktop"
+	case e2eTestDesktopMsgTrigger:
+		return "could not trigger pipeline for e2e test desktop"
+	default:
+		panic("unhandled error type")
+	}
+}
+
+type E2ETestDesktopError struct {
+	source string
+}
+
+type E2ETestDesktopTriggerInfo struct {
+	TriggerBranch string
+	TriggerPR     int
+	TriggerRepo   string
+	TriggerSHA    string
+	RefToTrigger  string
+	EnvVars       map[string]string
+}
+
+func (s *Server) handleE2ETestDesktop(ctx context.Context, commenter string, pr *model.PullRequest) error {
+	var e2eTestErr *E2ETestDesktopError
+	defer func() {
+		if e2eTestErr != nil {
+			if err := s.sendGitHubComment(ctx, pr.RepoOwner, pr.RepoName, pr.Number, e2eTestErr.source); err != nil {
+				mlog.Warn("Error while commenting", mlog.Err(err))
+			}
+		}
+	}()
+	if !s.IsOrgMember(commenter) {
+		e2eTestErr = &E2ETestDesktopError{source: e2eTestDesktopMsgCommenterPermission}
+		return e2eTestErr
+	}
+	prRepoOwner, prRepoName, prNumber := pr.RepoOwner, pr.RepoName, pr.Number
+
+	isCIPassing, err := s.areChecksSuccessfulForPR(ctx, pr)
+	if err != nil {
+		e2eTestErr = &E2ETestDesktopError{source: e2eTestDesktopMsgUnknownPRState}
+		return e2eTestErr
+	}
+	if !isCIPassing {
+		e2eTestErr = &E2ETestDesktopError{source: e2eTestDesktopMsgCIFailing}
+		return e2eTestErr
+	}
+
+	info := &E2ETestDesktopTriggerInfo{
+		TriggerBranch: pr.Ref,
+		TriggerPR:     pr.Number,
+		TriggerRepo:   pr.RepoName,
+		TriggerSHA:    pr.Sha,
+	}
+
+	info.RefToTrigger = s.Config.E2EDesktopGitLabProjectRefForPR
+
+	url, err := s.triggerE2EDesktopGitLabPipeline(ctx, info)
+	if err != nil {
+		e2eTestErr = &E2ETestDesktopError{source: e2eTestDesktopMsgTrigger}
+		return e2eTestErr
+	}
+	endMsg := fmt.Sprintf(e2eTestDesktopFmtSuccess, e2eTestDesktopMsgSuccess, url)
+	if cErr := s.sendGitHubComment(ctx, prRepoOwner, prRepoName, prNumber, endMsg); cErr != nil {
+		mlog.Warn("Error while commenting", mlog.Err(cErr))
+	}
+
+	return nil
+}

--- a/server/e2e_test_desktop_command_test.go
+++ b/server/e2e_test_desktop_command_test.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/xanzy/go-gitlab"
+
+	"github.com/mattermost/mattermost-mattermod/model"
+	"github.com/mattermost/mattermost-mattermod/server/mocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-github/v39/github"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleE2ETestingDesktop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	const userHandle = "user"
+	const organization = "mattertest"
+	s := Server{
+		Config: &Config{
+			Org:                     organization,
+			E2EDesktopGitLabProject: "qa%2Fdesktop-e2e-testing",
+			E2EDesktopCoreReponame:  "desktop",
+		},
+		GithubClient:     &GithubClient{},
+		GitLabCIClientV4: &GitLabClient{},
+	}
+
+	ctx := context.Background()
+
+	msg := new(string)
+	comment := &github.IssueComment{Body: msg}
+	is := mocks.NewMockIssuesService(ctrl)
+	rs := mocks.NewMockRepositoriesService(ctrl)
+	prs := mocks.NewMockPullRequestsService(ctrl)
+	glPS := mocks.NewMockPipelinesService(ctrl)
+	s.GithubClient.Issues = is
+	s.GithubClient.Repositories = rs
+	s.GithubClient.PullRequests = prs
+	s.GitLabCIClientV4.Pipelines = glPS
+
+	gCtxInterface := reflect.TypeOf(gitlab.RequestOptionFunc(nil))
+	ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
+
+	t.Run("happy trigger from desktop core without options", func(t *testing.T) {
+		s.OrgMembers = make([]string, 1)
+		s.OrgMembers[0] = userHandle
+		pr := &model.PullRequest{
+			RepoOwner: userHandle,
+			RepoName:  s.Config.E2EDesktopCoreReponame,
+			Number:    prNumber,
+			Ref:       eBranch,
+			Sha:       eSHA,
+		}
+		pr.FullName = organization + "/" + userHandle
+		rs.EXPECT().
+			GetCombinedStatus(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, s.Config.E2EDesktopCoreReponame, gomock.Any(), nil).
+			Times(1).
+			Return(&github.CombinedStatus{
+				State: github.String(statePending),
+			}, nil, nil)
+
+		p := &gitlab.Pipeline{WebURL: "https://your.gitlab.com/project/-/pipelines/54004"}
+		glPS.EXPECT().CreatePipeline(s.Config.E2EDesktopGitLabProject, gomock.Any(), gomock.AssignableToTypeOf(gCtxInterface)).Times(1).Return(p, nil, nil)
+		commentEnd := &github.IssueComment{Body: github.String(fmt.Sprintf(e2eTestDesktopFmtSuccess, e2eTestDesktopMsgSuccess, p.WebURL))}
+		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, commentEnd).Times(1).Return(nil, nil, nil)
+		err := s.handleE2ETestDesktop(ctx, userHandle, pr)
+		require.NoError(t, err)
+	})
+	t.Run("random user", func(t *testing.T) {
+		*msg = e2eTestDesktopMsgCommenterPermission
+		pr := &model.PullRequest{
+			RepoOwner: userHandle,
+			RepoName:  s.Config.E2EDesktopCoreReponame,
+			Number:    123,
+		}
+		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, comment).Times(1).Return(nil, nil, nil)
+		err := s.handleE2ETestDesktop(ctx, "someone", pr)
+		require.Error(t, err)
+		require.IsType(t, &E2ETestDesktopError{}, err)
+		require.Equal(t, err.(*E2ETestDesktopError).source, *msg)
+	})
+	t.Run("pr not ready", func(t *testing.T) {
+		*msg = e2eTestDesktopMsgCIFailing
+		s.OrgMembers = make([]string, 1)
+		s.OrgMembers[0] = userHandle
+		pr := &model.PullRequest{
+			RepoOwner: userHandle,
+			RepoName:  s.Config.E2EDesktopCoreReponame,
+			Number:    123,
+		}
+		pr.FullName = organization + "/" + userHandle
+		rs.EXPECT().
+			GetCombinedStatus(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, s.Config.E2EDesktopCoreReponame, gomock.Any(), nil).
+			Times(1).
+			Return(&github.CombinedStatus{
+				State: github.String(stateError), // statePending can run e2e-test (block-pr-merge.go)
+			}, nil, nil)
+		is.EXPECT().CreateComment(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, comment).Times(1).Return(nil, nil, nil)
+		err := s.handleE2ETestDesktop(ctx, userHandle, pr)
+		require.Error(t, err)
+		require.IsType(t, &E2ETestDesktopError{}, err)
+		require.Equal(t, err.(*E2ETestDesktopError).source, *msg)
+	})
+}

--- a/server/e2e_test_mobile_command.go
+++ b/server/e2e_test_mobile_command.go
@@ -80,7 +80,7 @@ func (s *Server) handleE2ETestMobile(ctx context.Context, commenter string, pr *
 		TriggerSHA:    pr.Sha,
 	}
 
-	info.RefToTrigger = "main"
+	info.RefToTrigger = s.Config.E2EMobileGitLabProjectRefForPR
 
 	url, err := s.triggerE2EMobileGitLabPipeline(ctx, info)
 	if err != nil {

--- a/server/gitlab.go
+++ b/server/gitlab.go
@@ -15,6 +15,8 @@ const (
 	envKeyShaMattermostWebapp = "SHA_MATTERMOST_WEBAPP"
 	envKeyRefMattermostMobile = "REF_MATTERMOST_MOBILE"
 	envKeyShaMattermostMobile = "SHA_MATTERMOST_MOBILE"
+	envKeyRefDesktop          = "REF_DESKTOP"
+	envKeyShaDesktop          = "SHA_DESKTOP"
 	variableTypeEnvVar        = "env_var"
 )
 
@@ -116,6 +118,36 @@ func (s *Server) triggerE2EMobileGitLabPipeline(ctx context.Context, info *E2ETe
 		Variables: defaultEnvs,
 	}
 	pip, _, err := s.GitLabCIClientV4.Pipelines.CreatePipeline(s.Config.E2EMobileGitLabProject, createOpts, gitlab.WithContext(ctx))
+	if err != nil {
+		return "", err
+	}
+
+	return pip.WebURL, nil
+}
+
+func (s *Server) triggerE2EDesktopGitLabPipeline(ctx context.Context, info *E2ETestDesktopTriggerInfo) (string, error) {
+	defaultEnvs := []*gitlab.PipelineVariable{
+		{
+			Key:          envKeyPRNumber,
+			Value:        strconv.Itoa(info.TriggerPR),
+			VariableType: variableTypeEnvVar,
+		},
+		{
+			Key:          envKeyRefDesktop,
+			Value:        info.TriggerBranch,
+			VariableType: variableTypeEnvVar,
+		},
+		{
+			Key:          envKeyShaDesktop,
+			Value:        info.TriggerSHA,
+			VariableType: variableTypeEnvVar,
+		},
+	}
+	createOpts := &gitlab.CreatePipelineOptions{
+		Ref:       &info.RefToTrigger,
+		Variables: defaultEnvs,
+	}
+	pip, _, err := s.GitLabCIClientV4.Pipelines.CreatePipeline(s.Config.E2EDesktopGitLabProject, createOpts, gitlab.WithContext(ctx))
 	if err != nil {
 		return "", err
 	}

--- a/server/issue_comment_handler.go
+++ b/server/issue_comment_handler.go
@@ -140,7 +140,14 @@ func (s *Server) issueCommentEventHandler(w http.ResponseWriter, r *http.Request
 			s.Metrics.IncreaseWebhookRequest("e2e_test_mobile")
 			if err := s.handleE2ETestMobile(ctx, commenter, pr); err != nil {
 				s.Metrics.IncreaseWebhookErrors("e2e_test_mobile")
-				errs = append(errs, fmt.Errorf("error e2e test: %w", err))
+				errs = append(errs, fmt.Errorf("error e2e test mobile: %w", err))
+			}
+		}
+		if s.Config.E2EDesktopCoreReponame == *ev.Repository.Name {
+			s.Metrics.IncreaseWebhookRequest("e2e_test_desktop")
+			if err := s.handleE2ETestDesktop(ctx, commenter, pr); err != nil {
+				s.Metrics.IncreaseWebhookErrors("e2e_test_desktop")
+				errs = append(errs, fmt.Errorf("error e2e test desktop: %w", err))
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
--> Copy, paste and adapt of the mobile e2e testing command from here https://github.com/mattermost/mattermost-mattermod/pull/327 . Added improvement to trigger separate branches in GitLab for PR and main. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

