### PR TITLE
cloud fast forward: check branch names instead of commit dates

### DIFF
--- a/server/fast_forward_test.go
+++ b/server/fast_forward_test.go
@@ -130,12 +130,6 @@ func TestPerformFastForwardProcess(t *testing.T) {
 				},
 			},
 		}, nil, nil)
-		now := time.Now()
-		gs.EXPECT().GetCommit(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, cloudRepo1, "some-random-sha").Times(1).Return(&github.Commit{
-			Author: &github.CommitAuthor{
-				Date: &now,
-			},
-		}, nil, nil)
 
 		ctx := context.Background()
 		res, err := s.performFastForwardProcess(ctx, issue, "/cloud-ff", member)
@@ -153,22 +147,19 @@ func TestPerformFastForwardProcess(t *testing.T) {
 		}
 		gs := mocks.NewMockGitService(ctrl)
 		s.GithubClient.Git = gs
+		sixDaysBefore := time.Now().Add(-1 * 6 * 24 * time.Hour)
+
 		gs.EXPECT().ListMatchingRefs(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, cloudRepo1, &github.ReferenceListOptions{
 			Ref: cloudBranchName,
 		}).Times(1).Return([]*github.Reference{
 			{
-				Ref: github.String("heads/cloud-" + time.Now().Format("2006-01-02") + "-backup"),
+				Ref: github.String("heads/cloud-" + time.Now().Format(fmt.Sprintf("%d-%d-%d", sixDaysBefore.Year(), sixDaysBefore.Month(), sixDaysBefore.Day())) + "-backup"),
 				Object: &github.GitObject{
 					SHA: github.String("some-random-sha"),
 				},
 			},
 		}, nil, nil)
-		now := time.Now().Add(-1 * 6 * 24 * time.Hour)
-		gs.EXPECT().GetCommit(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, cloudRepo1, "some-random-sha").Times(1).Return(&github.Commit{
-			Author: &github.CommitAuthor{
-				Date: &now,
-			},
-		}, nil, nil)
+
 		gs.EXPECT().GetRef(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, cloudRepo1, cloudBranchName).Times(1).Return(&github.Reference{
 			Object: &github.GitObject{
 				SHA: github.String("some-random-sha"),
@@ -206,12 +197,6 @@ func TestPerformFastForwardProcess(t *testing.T) {
 				Object: &github.GitObject{
 					SHA: github.String("some-random-sha"),
 				},
-			},
-		}, nil, nil)
-		now := time.Now()
-		gs.EXPECT().GetCommit(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, cloudRepo1, "some-random-sha").Times(1).Return(&github.Commit{
-			Author: &github.CommitAuthor{
-				Date: &now,
 			},
 		}, nil, nil)
 		gs.EXPECT().GetRef(gomock.AssignableToTypeOf(ctxInterface), s.Config.Org, cloudRepo1, cloudBranchName).Times(1).Return(&github.Reference{


### PR DESCRIPTION


#### Summary
Copied over ticket, It seems like there is a weird behavior that causes taking backup if there is no need to. Our decision-making algorithm works like this:

- Get the most recent backup branch
- Check if the  head commit is older than 5 days, If so take a backup
- Delete the cloud branch
- Create the backup
- Create a new cloud branch

In this case, if you run a `/cloud-ff` command, in the first run everything looks fine. But in the second run, it should be idempotent. But if the `master` branch has last commit more than 5 days ago, it's thinking that we haven't backed up that branch yet. Hence, creating new backups. We should look at the branch names here.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48376
