### PR TITLE
[CLD-5451] [feat] Ability to set git merge.renamelimit variable

### DIFF
--- a/config/config-mattermod.default.json
+++ b/config/config-mattermod.default.json
@@ -5,6 +5,7 @@
     "GitHubTokenReserve": 10,
     "GithubUsername": "",
     "GithubEmail": "",
+    "GitConfigMergeRenameLimit": "15000",
     "GithubAccessTokenCherryPick": "",
     "GithubWebhookSecret": "",
     "Org": "",

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -372,6 +372,17 @@ func cloneRepo(ctx context.Context, cfg *Config, repoName string) error {
 		}
 	}
 
+	// Set git config merge.renameLimit
+	cmd = exec.CommandContext(ctx, "git", "config", "merge.renameLimit")
+	if out, err := runCommandWithOutput(cmd, filepath.Join(cfg.RepoFolder, repoName)); err != nil {
+		return err
+	} else if out == "" { // this means merge.renameLimit is not set
+		cmd = exec.CommandContext(ctx, "git", "config", "merge.renameLimit", cfg.GitConfigMergeRenameLimit)
+		if err = runCommand(cmd, filepath.Join(cfg.RepoFolder, repoName)); err != nil {
+			return err
+		}
+	}
+
 	// Set upstream
 	cmd = exec.CommandContext(ctx, "git", "remote", "add", "upstream", "git@github.com:"+upstreamSlug+".git")
 	if err := runCommand(cmd, filepath.Join(cfg.RepoFolder, repoName)); err != nil {

--- a/server/config.go
+++ b/server/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	GitHubTokenReserve          int
 	GithubUsername              string
 	GithubEmail                 string
+	GitConfigMergeRenameLimit   string
 	GithubAccessTokenCherryPick string
 	GitHubWebhookSecret         string
 	Org                         string


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Example of issue thrown: https://github.com/mattermost/mattermost-server/pull/22568#issuecomment-1488555380

We are configuring mattermod, to dynamically raise the limit `merge.renamelimit`. 
 
**merge.renamelimit**
_The number of files to consider in the exhaustive portion of rename detection during a merge. If not specified, defaults to the value of diff.renameLimit. If neither merge.renameLimit nor diff.renameLimit are specified, currently defaults to 7000. This setting has no effect if rename detection is turned off._

https://git-scm.com/docs/git-merge#Documentation/git-merge.txt-mergerenameLimit


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-5451

