### PR TITLE
Require no reviews to e2e test

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,8 +14,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.1

--- a/server/e2e_test_from_label.go
+++ b/server/e2e_test_from_label.go
@@ -41,23 +41,6 @@ func (s *Server) triggerE2ETestFromLabel(pr *model.PullRequest) {
 		}
 	}()
 
-	prReviews, _, err := s.GithubClient.PullRequests.ListReviews(ctx, pr.RepoOwner, pr.RepoName, pr.Number, nil)
-	if err != nil {
-		mlog.Error("Error getting reviews for the PR",
-			mlog.Int("pr", pr.Number),
-			mlog.String("repo", pr.RepoName),
-			mlog.Err(err))
-		return
-	}
-	if !hasAtLeastOneApproval(prReviews) {
-		e2eTestFromLabelErr = &E2ETestFromLabelError{source: e2eTestFromLabelMsgPRHasNoApprovals}
-		mlog.Warn("Not triggering E2E test, due to missing required approvals",
-			mlog.Int("pr", pr.Number),
-			mlog.String("repo", pr.RepoName),
-			mlog.Err(e2eTestFromLabelErr))
-		return
-	}
-
 	ghPR, _, err := s.GithubClient.PullRequests.Get(ctx, pr.RepoOwner, pr.RepoName, pr.Number)
 	if err != nil {
 		mlog.Error("Error in getting the PR info",
@@ -85,18 +68,6 @@ func (s *Server) triggerE2ETestFromLabel(pr *model.PullRequest) {
 			mlog.String("repo", pr.RepoName),
 			mlog.Err(err))
 	}
-}
-
-func hasAtLeastOneApproval(reviews []*github.PullRequestReview) bool {
-	for _, review := range reviews {
-		mlog.Debug("Checking review state",
-			mlog.String("pr", review.GetPullRequestURL()),
-			mlog.String("state", review.GetState()))
-		if review.GetState() == prReviewApproved {
-			return true
-		}
-	}
-	return false
 }
 
 func isMergeable(pr *github.PullRequest) bool {

--- a/server/e2e_test_from_label_test.go
+++ b/server/e2e_test_from_label_test.go
@@ -148,6 +148,9 @@ func TestE2EFromLabelWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// The handler function is asynchronous, so give it time to run.
+		time.Sleep(200 * time.Millisecond)
 	}
 
 	t.Run("happy path", func(t *testing.T) {

--- a/server/e2e_test_from_label_test.go
+++ b/server/e2e_test_from_label_test.go
@@ -159,17 +159,8 @@ func TestE2EFromLabelWorkflow(t *testing.T) {
 		event.Label.Name = github.String(s.Config.E2ETriggerLabel[0])
 		prGhModel.MergeableState = github.String("clean")
 
-		prApprovalReviews := []*github.PullRequestReview{
-			{
-				State:          github.String(prReviewApproved),
-				PullRequestURL: github.String("https://github.com/mattermost-webapp/pulls/12345"),
-			},
-		}
 		setUpCommonMocks()
 
-		prs.EXPECT().
-			ListReviews(gomock.AssignableToTypeOf(ctxInterface), repoOwner, repo, 1, nil).
-			Return(prApprovalReviews, nil, nil)
 		prs.EXPECT().Get(gomock.AssignableToTypeOf(ctxInterface), repoOwner, repo, event.PRNumber).
 			Return(prGhModel, nil, nil).
 			Times(1)
@@ -190,29 +181,6 @@ func TestE2EFromLabelWorkflow(t *testing.T) {
 
 		runTestEvent()
 	})
-	t.Run("PR not approved", func(t *testing.T) {
-		msgPRNotApproved := e2eTestFromLabelMsgPRHasNoApprovals
-		commentPRNotApproved := &github.IssueComment{Body: &msgPRNotApproved}
-		event.Label.Name = github.String(s.Config.E2ETriggerLabel[0])
-		prReviewsNotApproved := []*github.PullRequestReview{
-			{
-				State: github.String("changes_requested"),
-			},
-		}
-
-		setUpCommonMocks()
-
-		prs.EXPECT().
-			ListReviews(gomock.AssignableToTypeOf(ctxInterface), repoOwner, repo, 1, nil).
-			Return(prReviewsNotApproved, nil, nil).
-			Times(1)
-
-		is.EXPECT().
-			CreateComment(gomock.AssignableToTypeOf(ctxInterface), repoOwner, repo, 1, commentPRNotApproved).
-			Times(1)
-
-		runTestEvent()
-	})
 	t.Run("PR not mergeable", func(t *testing.T) {
 		msgNotMergeable := e2eTestFromLabelMsgPRNotMergeable
 		commentNotMergeable := &github.IssueComment{Body: &msgNotMergeable}
@@ -221,16 +189,6 @@ func TestE2EFromLabelWorkflow(t *testing.T) {
 
 		setUpCommonMocks()
 
-		prReviewsApproved := []*github.PullRequestReview{
-			{
-				State:          github.String(prReviewApproved),
-				PullRequestURL: github.String("https://github.com/mattermost-webapp/pulls/12345"),
-			},
-		}
-		prs.EXPECT().
-			ListReviews(gomock.AssignableToTypeOf(ctxInterface), repoOwner, repo, 1, nil).
-			Return(prReviewsApproved, nil, nil).
-			Times(1)
 		prs.EXPECT().Get(gomock.AssignableToTypeOf(ctxInterface), repoOwner, repo, event.PRNumber).
 			Return(prGhModel, nil, nil).
 			Times(1)

--- a/server/github.go
+++ b/server/github.go
@@ -17,11 +17,10 @@ import (
 )
 
 const (
-	statePending     = "pending"
-	stateSuccess     = "success"
-	stateError       = "error"
-	prEventOpened    = "opened"
-	prReviewApproved = "APPROVED"
+	statePending  = "pending"
+	stateSuccess  = "success"
+	stateError    = "error"
+	prEventOpened = "opened"
 )
 
 func (s *Server) GetPullRequestFromGithub(ctx context.Context, pullRequest *github.PullRequest, action string) (*model.PullRequest, error) {


### PR DESCRIPTION
#### Summary
As per https://community.mattermost.com/core/pl/chexxbehjin5ffqo5kekeq9bqh, don't require a review to be able to run E2E tests. Running tests early should be encouraged help us catch issues early, reducing reviewer time.

#### Ticket Link
None.