### PR TITLE
Do not modify the user gitconfig

### DIFF
--- a/config/config-mattermod.default.json
+++ b/config/config-mattermod.default.json
@@ -5,7 +5,6 @@
     "GitHubTokenReserve": 10,
     "GithubUsername": "",
     "GithubEmail": "",
-    "GitConfigMergeRenameLimit": "15000",
     "GithubAccessTokenCherryPick": "",
     "GithubWebhookSecret": "",
     "Org": "",

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -367,13 +367,3 @@ func runCommand(cmd *exec.Cmd, dir string) error {
 	)
 	return cmd.Run()
 }
-
-func runCommandWithOutput(cmd *exec.Cmd, dir string) (string, error) {
-	cmd.Dir = dir
-	cmd.Env = append(
-		os.Environ(),
-		os.Getenv("PATH"),
-	)
-	out, err := cmd.CombinedOutput()
-	return string(out), err
-}

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -351,38 +351,6 @@ func cloneRepo(ctx context.Context, cfg *Config, repoName string) error {
 		return err
 	}
 
-	// Set username and email.
-	cmd = exec.CommandContext(ctx, "git", "config", "user.name")
-	if out, err := runCommandWithOutput(cmd, filepath.Join(cfg.RepoFolder, repoName)); err != nil {
-		return err
-	} else if out == "" { // this means username is not set
-		cmd = exec.CommandContext(ctx, "git", "config", "user.name", cfg.GithubUsername)
-		if err = runCommand(cmd, filepath.Join(cfg.RepoFolder, repoName)); err != nil {
-			return err
-		}
-	}
-
-	cmd = exec.CommandContext(ctx, "git", "config", "user.email")
-	if out, err := runCommandWithOutput(cmd, filepath.Join(cfg.RepoFolder, repoName)); err != nil {
-		return err
-	} else if out == "" { // this means email is not set
-		cmd = exec.CommandContext(ctx, "git", "config", "user.email", cfg.GithubEmail)
-		if err = runCommand(cmd, filepath.Join(cfg.RepoFolder, repoName)); err != nil {
-			return err
-		}
-	}
-
-	// Set git config merge.renameLimit
-	cmd = exec.CommandContext(ctx, "git", "config", "merge.renameLimit")
-	if out, err := runCommandWithOutput(cmd, filepath.Join(cfg.RepoFolder, repoName)); err != nil {
-		return err
-	} else if out == "" { // this means merge.renameLimit is not set
-		cmd = exec.CommandContext(ctx, "git", "config", "merge.renameLimit", cfg.GitConfigMergeRenameLimit)
-		if err = runCommand(cmd, filepath.Join(cfg.RepoFolder, repoName)); err != nil {
-			return err
-		}
-	}
-
 	// Set upstream
 	cmd = exec.CommandContext(ctx, "git", "remote", "add", "upstream", "git@github.com:"+upstreamSlug+".git")
 	if err := runCommand(cmd, filepath.Join(cfg.RepoFolder, repoName)); err != nil {

--- a/server/config.go
+++ b/server/config.go
@@ -61,7 +61,6 @@ type Config struct {
 	GitHubTokenReserve          int
 	GithubUsername              string
 	GithubEmail                 string
-	GitConfigMergeRenameLimit   string
 	GithubAccessTokenCherryPick string
 	GitHubWebhookSecret         string
 	Org                         string


### PR DESCRIPTION
#### Summary

Recently, mattermod failed to perform the cherry-pick operation, which seemed to be related to an inconsistency of expectations around repository cloning and user gitconfig management (tldr: mattermod modified the gitconfig at repo clone time; but repositories persist in an EBS volume, while `.gitconfig` gets lost on a Pod restart, leading to a situation where the repo is cloned but the gitconfig is not as expected). Please check [this discussion](https://community.mattermost.com/private-core/pl/xju696o8rbrwbjirng38yf6eue) for details.

This PR changes the way mattermod behaves in regard to the user gitconfig: instead of modifying it at repository clone time, it will instead assume that it's been already configured so that `git` commands will work as expected.
