### PR TITLE
CLD-6234 Cherrypick directly to upstream repo

### DIFF
--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -57,7 +57,7 @@ function make-a-pr() {
   local rel
   rel="$(basename "${BRANCH}")"
   echo
-  echo "+++ Creating a pull request on GitHub at ${GITHUB_USER}:${NEWBRANCH}"
+  echo "+++ Creating a pull request on GitHub at ${MAIN_REPO_ORG}:${NEWBRANCH}"
 
   # This looks like an unnecessary use of a tmpfile, but it avoids
   # https://github.com/github/hub/issues/976 Otherwise stdin is stolen
@@ -77,7 +77,7 @@ NONE
 
 EOF
 
-hub pull-request -F "${prtext}" -h "${GITHUB_USER}:${NEWBRANCH}" -b "${MAIN_REPO_ORG}:${rel}"
+hub pull-request -F "${prtext}" -h "${MAIN_REPO_ORG}:${NEWBRANCH}" -b "${MAIN_REPO_ORG}:${rel}"
 }
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -90,7 +90,7 @@ declare -r REBASEMAGIC="${REPO_ROOT}/.git/rebase-apply"
 DRY_RUN=${DRY_RUN:-""}
 REGENERATE_DOCS=${REGENERATE_DOCS:-""}
 UPSTREAM_REMOTE=${UPSTREAM_REMOTE:-upstream}
-FORK_REMOTE=${FORK_REMOTE:-origin}
+FORK_REMOTE=${FORK_REMOTE:-upstream}
 MAIN_REPO_ORG=${MAIN_REPO_ORG:-$(git remote get-url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $3}')}
 MAIN_REPO_NAME=${MAIN_REPO_NAME:-$(git remote get-url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $4}')}
 
@@ -183,22 +183,6 @@ if [[ -n "${DRY_RUN}" ]]; then
   echo "To delete this branch:"
   echo
   echo "  git branch -D ${NEWBRANCHUNIQ}"
-  exit 0
-fi
-
-if git remote -v | grep ^"${FORK_REMOTE}" | grep "${MAIN_REPO_ORG}/${MAIN_REPO_NAME}.git"; then
-  echo "!!! You have ${FORK_REMOTE} configured as your ${MAIN_REPO_ORG}/${MAIN_REPO_NAME}.git"
-  echo "This isn't normal. Leaving you with push instructions:"
-  echo
-  echo "+++ First manually push the branch this script created:"
-  echo
-  echo "  git push REMOTE ${NEWBRANCHUNIQ}:${NEWBRANCH}"
-  echo
-  echo "where REMOTE is your personal fork (maybe ${UPSTREAM_REMOTE}? Consider swapping those.)."
-  echo "OR consider setting UPSTREAM_REMOTE and FORK_REMOTE to different values."
-  echo
-  make-a-pr
-  cleanbranch=""
   exit 0
 fi
 


### PR DESCRIPTION
#### Summary

This PR changes the cherry-picking script to push the automated cherry pick branches directly to the `upstream` repo, rather than its `origin` (which is assumed to be a fork; in fact this script originate from the [kubernetes community repo](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/cherry-picks.md), where contributions are obviously made from forks).

Example usage: [this PR](https://github.com/mattermost/test-private-project/pull/3) has been created by the following script.
```
# NB: for this to work on your machine, ensure that your ssh key is SSO-authorized against the mattermost org
export ORIGINAL_AUTHOR=mvitale1989
export GITHUB_USER=mvitale1989
export GITHUB_TOKEN=xxxxx
#export DRY_RUN=yes
git clone git@github.com:mattermost/test-private-project.git
cd test-private-project

# Add an `upstream` remote
git remote add upstream $(git remote get-url origin)
git fetch upstream
git checkout upstream/master

### Create dummy changes
BRANCHNAME="dummychange-$(date +%s)"
git checkout -b $BRANCHNAME
echo "dummycontent" > dummyfile
git add dummyfile
git commit -m "Add dummyfile"
git push --set-upstream origin $BRANCHNAME

## Create cherrypick PR of the HEAD commit against the master branch
## Make sure that you checkout this PR
../mattermost-mattermod/hack/cherry-pick.sh upstream/master dummyPR $(git rev-parse HEAD)
```

I added a few more infos in [this comment in the ticket](https://mattermost.atlassian.net/browse/CLD-6234?focusedCommentId=156622), since they include a few sensitive links.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6234