### PR TITLE
CLD-6234 - Adapt PR regex to new cherrypick script

### DIFF
--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -234,7 +234,7 @@ func (s *Server) doCherryPick(ctx context.Context, version string, milestoneNumb
 		}
 		return string(out), err
 	}
-	gitHubPR := regexp.MustCompile(`https://github.com/mattermost/.*\.*[0-9]+`)
+	gitHubPR := regexp.MustCompile(`https://github.com/mattermost/.*/pull/[0-9]+`)
 	newPRURL := gitHubPR.FindString(string(out))
 	newPR := strings.Split(newPRURL, "/")
 	newPRNumber, _ := strconv.Atoi(newPR[len(newPR)-1])


### PR DESCRIPTION
#### Summary

The previous PR worked, and mattermod is now able to create PRs directly against the repo (instead of its fork) for both public and private repos.

However,  some corollary operations (assigning reviewers, labeling the PR) do not work after merging the above change. Looking at the mattermod logs (which you can check out in [this comment](https://mattermost.atlassian.net/browse/CLD-6234?focusedCommentId=156788)) you can see that when mattermod tries to figure out the number of the PR it just created, it gets it wrong: e.g. it tries to send a POST request to `https://api.github.com/repos/mattermost/mattermost/issues/0/assign`.

The cause seems to be [this line](https://github.com/mattermost/mattermost-mattermod/blob/master/server/cherry_pick.go#L237): the regex `https://github.com/mattermost/.*\.*[0-9]+` expects the URL path to end with a dot plus the PR number (which was probably correct for PRs-from-forks), but we can see by running the cherry picking script locally that this is not the case right now:
```
### Output of: hub pull-request -F /tmp/prtext.D9eB -h mattermost:automated-cherry-pick-of-mattermost-#dummyPR-upstream-cld-6234-test-cherrypick-destination -b mattermost:cld-6234-test-cherrypick-destination
https://github.com/mattermost/mattermost/pull/24716
```

We needed to adapt the regexp according to this new output format.

You can check in [this comment](https://mattermost.atlassian.net/browse/CLD-6234?focusedCommentId=156794) the sample go program i used to test the new regex.


#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6234

