### PR TITLE
Debug unsuccessful combined status state

### DIFF
--- a/server/auto_merge.go
+++ b/server/auto_merge.go
@@ -76,6 +76,21 @@ func (s *Server) AutoMergePR() error {
 		}
 
 		if prStatus.GetState() != stateSuccess {
+			for _, status := range prStatus.Statuses {
+				mlog.Debug("status",
+					mlog.Int("pr", pr.Number),
+					mlog.String("repo", pr.RepoName),
+					mlog.String("state", status.GetState()),
+					mlog.String("description", status.GetDescription()),
+					mlog.String("context", status.GetContext()),
+					mlog.String("target_url", status.GetTargetURL()),
+				)
+			}
+
+			mlog.Error("PR is not ready to merge; combined status state is not success",
+				mlog.Int("pr", pr.Number),
+				mlog.String("repo", pr.RepoName),
+				mlog.String("state", prStatus.GetState()))
 			continue
 		}
 


### PR DESCRIPTION
#### Summary
Various translations PRs are failing to merge automatically. In the logs, they seem to entirely disappear during the ticks, e.g.:
![CleanShot 2023-10-11 at 17 05 13@2x](https://github.com/mattermost/mattermost-mattermod/assets/1023171/4ff8a486-6714-468e-b7ac-d063bb807543)

Add debug logging to the only exit point that currently fails to log in a bid to explain why this might be.

#### Ticket Link
None.