### PR TITLE
CLD-7237 Fix mattermod docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=builder /opt/hub/hub /usr/local/bin/hub
 COPY --from=builder /go/src/mattermod/dist/mattermod /usr/local/bin/
 COPY --from=builder /go/src/mattermod/hack/cherry-pick.sh /app/scripts/
 
+RUN usermod -d /app $(id -un 1000)
 WORKDIR /app
 
 RUN chown -R 1000:1000 /app


### PR DESCRIPTION
#### Summary

The following PR removed the user creation from mattermod's Dockerfile, since the new base (Ubuntu Noble) comes with its own `ubuntu` user out of the box: https://github.com/mattermost/mattermost-mattermod/pull/353/files

However, the mattermod helm chart assumes that the user with uid 1000 has its homedir in `/app`, and mounts some user-level configurations (e.g. `.gitconfig`) at that path.

So after the above change, mattermod is unable to do some operations, e.g. cherry-picking (because its looks for the ssh key it uses to pull from Github in `/home/ubuntu/.ssh/`, but the key is actually in `/app/.ssh/`): https://github.com/mattermost/mattermost/pull/25928#issuecomment-1964340153

Note that as an alternative, we could've instead changed the helm chart to mote the secrets to `/home/ubuntu` to make it work again. But both of these method essentially introduce the same assumptions about the base image, so I went with the more immediate Dockerfile method.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7237