### PR TITLE
Remove translation auto-merge functionality

### DIFF
--- a/config/config-mattermod.default.json
+++ b/config/config-mattermod.default.json
@@ -69,10 +69,6 @@
     "TranslationsMattermostWebhookURL": "",
     "TranslationsMattermostMessage": "",
     "TranslationsBot": "",
-    "TranslationsDoNotMergeLabel": "",
-    "TranslationsMergedMessage":"",
-    "TranslationsMergeFailureMessage":"",
-    "TranslationsMergePolicy":"rebase",
 
     "StartLoadtestTag": "",
     "StartLoadtestMessage": "",

--- a/server/auto_merge.go
+++ b/server/auto_merge.go
@@ -30,8 +30,7 @@ func (s *Server) AutoMergePR() error {
 
 	for _, pr := range prs {
 		var autoMergePr = s.hasAutoMerge(pr.Labels)
-		var translationPr = s.isTranslationPr(pr) && s.hasTranslationMergeLabel(pr.Labels)
-		if !autoMergePr && !translationPr {
+		if !autoMergePr {
 			continue
 		}
 
@@ -122,23 +121,11 @@ func (s *Server) AutoMergePR() error {
 			MergeMethod: "squash",
 		}
 
-		if translationPr {
-			opt.MergeMethod = s.Config.TranslationsMergePolicy
-		}
-
 		merged, _, err := s.GithubClient.PullRequests.Merge(ctx, pr.RepoOwner, pr.RepoName, pr.Number, "Automatic Merge", opt)
 		if err != nil {
 			errMsg := fmt.Sprintf("Error while trying to automerge the PR\nErr %s", err.Error())
 			if err = s.sendGitHubComment(ctx, pr.RepoOwner, pr.RepoName, pr.Number, errMsg); err != nil {
 				mlog.Warn("Error while commenting", mlog.Err(err))
-			}
-			if translationPr {
-				if err = s.removeTranslationLabel(ctx, pr); err != nil {
-					mlog.Warn("Error while removing translation label", mlog.Err(err))
-				}
-				if err = s.sendTranslationWebhookMessage(ctx, pr, s.Config.TranslationsMergeFailureMessage); err != nil {
-					mlog.Warn("Error while sending failure message to mattermost", mlog.Err(err))
-				}
 			}
 			continue
 		}
@@ -146,15 +133,6 @@ func (s *Server) AutoMergePR() error {
 		msg = fmt.Sprintf("%s\nSHA: %s", merged.GetMessage(), merged.GetSHA())
 		if err = s.sendGitHubComment(ctx, pr.RepoOwner, pr.RepoName, pr.Number, msg); err != nil {
 			mlog.Warn("Error while commenting", mlog.Err(err))
-		}
-
-		if translationPr {
-			if err = s.removeTranslationLabel(ctx, pr); err != nil {
-				mlog.Warn("Error while removing translation label", mlog.Err(err))
-			}
-			if err = s.sendTranslationWebhookMessage(ctx, pr, s.Config.TranslationsMergedMessage); err != nil {
-				mlog.Warn("Error while sending translations merged message to mattermost", mlog.Err(err))
-			}
 		}
 	}
 

--- a/server/config.go
+++ b/server/config.go
@@ -90,10 +90,6 @@ type Config struct {
 	TranslationsMattermostWebhookURL string
 	TranslationsMattermostMessage    string
 	TranslationsBot                  string
-	TranslationsDoNotMergeLabel      string
-	TranslationsMergedMessage        string
-	TranslationsMergeFailureMessage  string
-	TranslationsMergePolicy          string
 
 	StartLoadtestTag     string
 	StartLoadtestMessage string

--- a/server/translations.go
+++ b/server/translations.go
@@ -14,11 +14,6 @@ func (s *Server) handleTranslationPR(ctx context.Context, pr *model.PullRequest)
 		return
 	}
 
-	label := []string{s.Config.TranslationsDoNotMergeLabel}
-	_, _, errLabel := s.GithubClient.Issues.AddLabelsToIssue(ctx, pr.RepoOwner, pr.RepoName, pr.Number, label)
-	if errLabel != nil {
-		mlog.Error("Unable to label", mlog.Err(errLabel))
-	}
 	err := s.sendTranslationWebhookMessage(ctx, pr, s.Config.TranslationsMattermostMessage)
 	if err != nil {
 		mlog.Error("Unable to send message ", mlog.Err(err))
@@ -39,24 +34,6 @@ func (s *Server) sendTranslationWebhookMessage(ctx context.Context, pr *model.Pu
 	return nil
 }
 
-func (s *Server) removeTranslationLabel(ctx context.Context, pr *model.PullRequest) error {
-	_, err := s.GithubClient.Issues.RemoveLabelForIssue(ctx, pr.RepoOwner, pr.RepoName, pr.Number, s.Config.TranslationsDoNotMergeLabel)
-	if err != nil {
-		mlog.Error("Error removing the automated label in the translation auto merge", mlog.Err(err), mlog.Int("PR", pr.Number), mlog.String("Repo", pr.RepoName))
-		return err
-	}
-	return nil
-}
-
 func (s *Server) isTranslationPr(pr *model.PullRequest) bool {
 	return pr.Username == s.Config.TranslationsBot
-}
-
-func (s *Server) hasTranslationMergeLabel(labels []string) bool {
-	for _, label := range labels {
-		if label == s.Config.TranslationsDoNotMergeLabel {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary
In the distant past, we had to constantly fix merge conflicts between Weblate and Mattermost. After a long investigation with Tom DeMoor, we landed on a workflow that involves locking Weblate, pushing the changes, merging them, then resetting Weblate to upstream. This has essentially resolved the issue and been live for the last year.

Let's clean up this legacy "do not merge" label for translations PRs that was preivously meant to block developers from "merging wrong" -- now we can just squash and merge like any other PR.

- Remove automatic labeling and merging logic for translation PRs
- Remove unused config fields related to translation merging
- Preserve translation PR detection and webhook notifications

🤖 Generated with [Claude Code](https://claude.ai/code)