### PR TITLE
Use source branch for cherry-pick PRs

### DIFF
--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -150,8 +150,9 @@ fi
 
 TARGET_BRANCH="$(basename "${BRANCH}")"
 declare -r TARGET_BRANCH
-# For source branch my-branch targeting release-11.7, create my-branch-release-11.7.
-NEWBRANCH="$(echo "${SOURCE_BRANCH}-${TARGET_BRANCH}" | sed 's/\//-/g')"
+# For source branch my-branch targeting release-11.7, create
+# automated-cherry-pick-of-my-branch-release-11.7
+NEWBRANCH="$(echo "automated-cherry-pick-of-${SOURCE_BRANCH}-${TARGET_BRANCH}" | sed 's/\//-/g')"
 declare -r NEWBRANCH
 NEWBRANCHUNIQ="${NEWBRANCH}-$(date +%s)"
 declare -r NEWBRANCHUNIQ

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -103,8 +103,8 @@ if ! which hub > /dev/null; then
   exit 1
 fi
 
-if [[ "$#" -lt 3 ]]; then
-  echo "${0} <remote branch> <pr-number> <commit-sha> [source-branch]: cherry pick <commit-sha> from <pr> onto <remote branch> and leave instructions for proposing pull request"
+if [[ "$#" -lt 4 ]]; then
+  echo "${0} <remote branch> <pr-number> <commit-sha> <source-branch>: cherry pick <commit-sha> from <pr> onto <remote branch> and leave instructions for proposing pull request"
   echo
   echo "  Checks out <remote branch> and handles the cherry-pick of <commit> for you."
   echo "  Examples:"
@@ -133,7 +133,7 @@ fi
 declare -r BRANCH="$1"
 declare -r PULL="$2"
 declare -r COMMITSHA="$3"
-declare -r SOURCE_BRANCH="${4:-}"
+declare -r SOURCE_BRANCH="$4"
 
 echo "+++ Updating remotes..."
 git remote update "${UPSTREAM_REMOTE}" "${FORK_REMOTE}"
@@ -150,11 +150,8 @@ FALLBACK_NEWBRANCH="$(echo "${FALLBACK_NEWBRANCHREQ}-${BRANCH}" | sed 's/\//-/g'
 declare -r FALLBACK_NEWBRANCH
 TARGET_BRANCH="$(basename "${BRANCH}")"
 declare -r TARGET_BRANCH
-if [[ -n "${SOURCE_BRANCH}" ]]; then
-  NEWBRANCH="$(echo "${SOURCE_BRANCH}-${TARGET_BRANCH}" | sed 's/\//-/g')"
-else
-  NEWBRANCH="${FALLBACK_NEWBRANCH}"
-fi
+# For source branch my-branch targeting release-11.7, create my-branch-release-11.7.
+NEWBRANCH="$(echo "${SOURCE_BRANCH}-${TARGET_BRANCH}" | sed 's/\//-/g')"
 declare -r NEWBRANCH
 NEWBRANCHUNIQ="${FALLBACK_NEWBRANCH}-$(date +%s)"
 declare -r NEWBRANCHUNIQ
@@ -202,9 +199,5 @@ echo "  git push ${FORK_REMOTE} ${NEWBRANCHUNIQ}:${NEWBRANCH}"
 echo
 
 
-if [[ -n "${SOURCE_BRANCH}" ]]; then
-  git push "${FORK_REMOTE}" "${NEWBRANCHUNIQ}:${NEWBRANCH}"
-else
-  git push "${FORK_REMOTE}" -f "${NEWBRANCHUNIQ}:${NEWBRANCH}"
-fi
+git push "${FORK_REMOTE}" "${NEWBRANCHUNIQ}:${NEWBRANCH}"
 make-a-pr

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -134,6 +134,10 @@ declare -r BRANCH="$1"
 declare -r PULL="$2"
 declare -r COMMITSHA="$3"
 declare -r SOURCE_BRANCH="$4"
+if [[ -z "${SOURCE_BRANCH}" ]]; then
+  echo "error: source branch (argument 4) must not be empty" >&2
+  exit 1
+fi
 
 echo "+++ Updating remotes..."
 git remote update "${UPSTREAM_REMOTE}" "${FORK_REMOTE}"

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -144,16 +144,12 @@ if ! git log -n1 --format=%H "${BRANCH}" >/dev/null 2>&1; then
   exit 1
 fi
 
-FALLBACK_NEWBRANCHREQ="automated-cherry-pick-of-${MAIN_REPO_NAME}-#${PULL}" # "Required" portion for tools.
-declare -r FALLBACK_NEWBRANCHREQ
-FALLBACK_NEWBRANCH="$(echo "${FALLBACK_NEWBRANCHREQ}-${BRANCH}" | sed 's/\//-/g')"
-declare -r FALLBACK_NEWBRANCH
 TARGET_BRANCH="$(basename "${BRANCH}")"
 declare -r TARGET_BRANCH
 # For source branch my-branch targeting release-11.7, create my-branch-release-11.7.
 NEWBRANCH="$(echo "${SOURCE_BRANCH}-${TARGET_BRANCH}" | sed 's/\//-/g')"
 declare -r NEWBRANCH
-NEWBRANCHUNIQ="${FALLBACK_NEWBRANCH}-$(date +%s)"
+NEWBRANCHUNIQ="${NEWBRANCH}-$(date +%s)"
 declare -r NEWBRANCHUNIQ
 echo "+++ Creating local branch ${NEWBRANCHUNIQ}"
 

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -18,8 +18,7 @@
 
 # Checkout a PR from GitHub. (Yes, this is sitting in a Git tree. How
 # meta.) Assumes you care about pulls from remote "upstream" and
-# checks them out to a branch named:
-#  automated-cherry-pick-of-<pr>-<target branch>-<timestamp>
+# opens pull requests from a branch named after the original source branch when available.
 
 # Modified by Mattermost to do a real cherry-pick instead of applying patches
 # via git am
@@ -104,12 +103,12 @@ if ! which hub > /dev/null; then
   exit 1
 fi
 
-if [[ "$#" -lt 2 ]]; then
-  echo "${0} <remote branch> <pr-number> <commit-sha>: cherry pick <commit-sha> from <pr> onto <remote branch> and leave instructions for proposing pull request"
+if [[ "$#" -lt 3 ]]; then
+  echo "${0} <remote branch> <pr-number> <commit-sha> [source-branch]: cherry pick <commit-sha> from <pr> onto <remote branch> and leave instructions for proposing pull request"
   echo
   echo "  Checks out <remote branch> and handles the cherry-pick of <commit> for you."
   echo "  Examples:"
-  echo "    $0 upstream/release-3.14 12345 df243fd # Cherry-picks commit sha df243fd onto upstream/release-3.14 and proposes that as a PR with a commit message referring to PR 12345"
+  echo "    $0 upstream/release-3.14 12345 df243fd my-feature-branch # Cherry-picks commit sha df243fd onto upstream/release-3.14 and proposes that as a PR from my-feature-branch"
   echo
   echo "  Set the DRY_RUN environment var to skip git push and creating PR."
   echo "  This is useful for creating patches to a release branch without making a PR."
@@ -134,6 +133,7 @@ fi
 declare -r BRANCH="$1"
 declare -r PULL="$2"
 declare -r COMMITSHA="$3"
+declare -r SOURCE_BRANCH="${4:-}"
 
 echo "+++ Updating remotes..."
 git remote update "${UPSTREAM_REMOTE}" "${FORK_REMOTE}"
@@ -144,11 +144,13 @@ if ! git log -n1 --format=%H "${BRANCH}" >/dev/null 2>&1; then
   exit 1
 fi
 
-NEWBRANCHREQ="automated-cherry-pick-of-${MAIN_REPO_NAME}-#${PULL}" # "Required" portion for tools.
-declare -r NEWBRANCHREQ
-NEWBRANCH="$(echo "${NEWBRANCHREQ}-${BRANCH}" | sed 's/\//-/g')"
+FALLBACK_NEWBRANCHREQ="automated-cherry-pick-of-${MAIN_REPO_NAME}-#${PULL}" # "Required" portion for tools.
+declare -r FALLBACK_NEWBRANCHREQ
+FALLBACK_NEWBRANCH="$(echo "${FALLBACK_NEWBRANCHREQ}-${BRANCH}" | sed 's/\//-/g')"
+declare -r FALLBACK_NEWBRANCH
+NEWBRANCH="${SOURCE_BRANCH:-${FALLBACK_NEWBRANCH}}"
 declare -r NEWBRANCH
-NEWBRANCHUNIQ="${NEWBRANCH}-$(date +%s)"
+NEWBRANCHUNIQ="${FALLBACK_NEWBRANCH}-$(date +%s)"
 declare -r NEWBRANCHUNIQ
 echo "+++ Creating local branch ${NEWBRANCHUNIQ}"
 
@@ -194,5 +196,9 @@ echo "  git push ${FORK_REMOTE} ${NEWBRANCHUNIQ}:${NEWBRANCH}"
 echo
 
 
-git push "${FORK_REMOTE}" -f "${NEWBRANCHUNIQ}:${NEWBRANCH}"
+if [[ -n "${SOURCE_BRANCH}" ]]; then
+  git push "${FORK_REMOTE}" "${NEWBRANCHUNIQ}:${NEWBRANCH}"
+else
+  git push "${FORK_REMOTE}" -f "${NEWBRANCHUNIQ}:${NEWBRANCH}"
+fi
 make-a-pr

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -18,7 +18,7 @@
 
 # Checkout a PR from GitHub. (Yes, this is sitting in a Git tree. How
 # meta.) Assumes you care about pulls from remote "upstream" and
-# opens pull requests from a branch named after the original source branch when available.
+# opens pull requests from a branch named after the original source branch and target branch when available.
 
 # Modified by Mattermost to do a real cherry-pick instead of applying patches
 # via git am
@@ -108,7 +108,7 @@ if [[ "$#" -lt 3 ]]; then
   echo
   echo "  Checks out <remote branch> and handles the cherry-pick of <commit> for you."
   echo "  Examples:"
-  echo "    $0 upstream/release-3.14 12345 df243fd my-feature-branch # Cherry-picks commit sha df243fd onto upstream/release-3.14 and proposes that as a PR from my-feature-branch"
+  echo "    $0 upstream/release-3.14 12345 df243fd my-feature-branch # Cherry-picks commit sha df243fd onto upstream/release-3.14 and proposes that as a PR from my-feature-branch-release-3.14"
   echo
   echo "  Set the DRY_RUN environment var to skip git push and creating PR."
   echo "  This is useful for creating patches to a release branch without making a PR."
@@ -148,7 +148,13 @@ FALLBACK_NEWBRANCHREQ="automated-cherry-pick-of-${MAIN_REPO_NAME}-#${PULL}" # "R
 declare -r FALLBACK_NEWBRANCHREQ
 FALLBACK_NEWBRANCH="$(echo "${FALLBACK_NEWBRANCHREQ}-${BRANCH}" | sed 's/\//-/g')"
 declare -r FALLBACK_NEWBRANCH
-NEWBRANCH="${SOURCE_BRANCH:-${FALLBACK_NEWBRANCH}}"
+TARGET_BRANCH="$(basename "${BRANCH}")"
+declare -r TARGET_BRANCH
+if [[ -n "${SOURCE_BRANCH}" ]]; then
+  NEWBRANCH="$(echo "${SOURCE_BRANCH}-${TARGET_BRANCH}" | sed 's/\//-/g')"
+else
+  NEWBRANCH="${FALLBACK_NEWBRANCH}"
+fi
 declare -r NEWBRANCH
 NEWBRANCHUNIQ="${FALLBACK_NEWBRANCH}-$(date +%s)"
 declare -r NEWBRANCHUNIQ

--- a/server/cherry_pick.go
+++ b/server/cherry_pick.go
@@ -211,7 +211,7 @@ func (s *Server) doCherryPick(ctx context.Context, version string, milestoneNumb
 	cherryPickScript := filepath.Join(s.Config.ScriptsFolder, "cherry-pick.sh")
 
 	releaseBranch := fmt.Sprintf("upstream/%s", version)
-	cmd := exec.Command(cherryPickScript, releaseBranch, strconv.Itoa(pr.Number), pr.MergeCommitSHA)
+	cmd := exec.Command(cherryPickScript, releaseBranch, strconv.Itoa(pr.Number), pr.MergeCommitSHA, pr.Ref)
 	cmd.Dir = repoFolder
 	cmd.Env = append(
 		os.Environ(),

--- a/server/cherry_pick_test.go
+++ b/server/cherry_pick_test.go
@@ -212,6 +212,7 @@ esac
 	require.Len(t, args, 3)
 	branchParts := strings.SplitN(args[2], ":", 2)
 	require.Len(t, branchParts, 2)
+	assert.True(t, strings.HasPrefix(branchParts[0], "my-branch-release-11.7-"))
 	assert.Equal(t, "my-branch-release-11.7", branchParts[1])
 }
 

--- a/server/cherry_pick_test.go
+++ b/server/cherry_pick_test.go
@@ -212,8 +212,8 @@ esac
 	require.Len(t, args, 3)
 	branchParts := strings.SplitN(args[2], ":", 2)
 	require.Len(t, branchParts, 2)
-	assert.True(t, strings.HasPrefix(branchParts[0], "my-branch-release-11.7-"))
-	assert.Equal(t, "my-branch-release-11.7", branchParts[1])
+	assert.True(t, strings.HasPrefix(branchParts[0], "automated-cherry-pick-of-my-branch-release-11.7-"))
+	assert.Equal(t, "automated-cherry-pick-of-my-branch-release-11.7", branchParts[1])
 }
 
 func TestCherryPickScriptRejectsEmptySourceBranch(t *testing.T) {

--- a/server/cherry_pick_test.go
+++ b/server/cherry_pick_test.go
@@ -216,6 +216,45 @@ esac
 	assert.Equal(t, "my-branch-release-11.7", branchParts[1])
 }
 
+func TestCherryPickScriptRejectsEmptySourceBranch(t *testing.T) {
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0700))
+	repoRoot := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(repoRoot, 0700))
+
+	t.Setenv("FAKE_REPO_ROOT", repoRoot)
+	t.Setenv("GITHUB_USER", "mattermod")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	fakeGit := `#!/usr/bin/env bash
+set -e
+
+case "$1" in
+  rev-parse)
+    echo "$FAKE_REPO_ROOT"
+    ;;
+  symbolic-ref)
+    echo "master"
+    ;;
+esac
+`
+	writeExecutableTestFile(t, filepath.Join(binDir, "git"), fakeGit)
+	writeExecutableTestFile(t, filepath.Join(binDir, "hub"), "#!/usr/bin/env bash\nexit 0\n")
+
+	cmd := exec.Command(
+		"bash",
+		filepath.Join("..", "hack", "cherry-pick.sh"),
+		"upstream/release-11.7",
+		"123",
+		"merge-sha",
+		"",
+	)
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	assert.Contains(t, string(out), "error: source branch (argument 4) must not be empty")
+}
+
 func writeExecutableTestFile(t *testing.T, path string, content string) {
 	t.Helper()
 

--- a/server/cherry_pick_test.go
+++ b/server/cherry_pick_test.go
@@ -108,6 +108,7 @@ func TestDoCherryPickPassesSourceBranch(t *testing.T) {
 printf "%s\n" "$@" > "$CHERRY_PICK_ARGS_FILE"
 echo "https://github.com/mattermost/repo-name/pull/456"
 `
+	// #nosec G306 -- the test script must be executable because doCherryPick runs it directly.
 	require.NoError(t, os.WriteFile(filepath.Join(scriptsFolder, "cherry-pick.sh"), []byte(script), 0755))
 
 	s := Server{

--- a/server/cherry_pick_test.go
+++ b/server/cherry_pick_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -87,6 +89,66 @@ func TestHandleCherryPick(t *testing.T) {
 			require.NoError(t, err)
 		})
 	})
+}
+
+func TestDoCherryPickPassesSourceBranch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tempDir := t.TempDir()
+	repoName := "repo-name"
+	repoFolder := filepath.Join(tempDir, "repos")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoFolder, repoName), 0755))
+	scriptsFolder := filepath.Join(tempDir, "scripts")
+	require.NoError(t, os.MkdirAll(scriptsFolder, 0755))
+
+	argsFile := filepath.Join(tempDir, "args")
+	t.Setenv("CHERRY_PICK_ARGS_FILE", argsFile)
+	script := `#!/usr/bin/env bash
+printf "%s\n" "$@" > "$CHERRY_PICK_ARGS_FILE"
+echo "https://github.com/mattermost/repo-name/pull/456"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(scriptsFolder, "cherry-pick.sh"), []byte(script), 0755))
+
+	s := Server{
+		Config: &Config{
+			RepoFolder:    repoFolder,
+			ScriptsFolder: scriptsFolder,
+		},
+		OrgMembers: []string{
+			"org-member",
+		},
+		GithubClient: &GithubClient{},
+	}
+
+	pr := &model.PullRequest{
+		RepoOwner:      "mattermost",
+		RepoName:       repoName,
+		Number:         123,
+		Username:       "org-member",
+		MergeCommitSHA: "merge-sha",
+		Ref:            "feature/shared-branch",
+	}
+
+	ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
+	is := mocks.NewMockIssuesService(ctrl)
+	is.EXPECT().AddLabelsToIssue(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, 456, []string{"AutomatedCherryPick", "Changelog/Not Needed", "Docs/Not Needed"}).Return(nil, nil, nil)
+	is.EXPECT().AddLabelsToIssue(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, []string{"CherryPick/Done"}).Return(nil, nil, nil)
+	is.EXPECT().RemoveLabelForIssue(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, pr.Number, "CherryPick/Approved").Return(nil, nil)
+	is.EXPECT().AddAssignees(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, 456, []string{"org-member"}).Return(nil, nil, nil)
+	s.GithubClient.Issues = is
+
+	prs := mocks.NewMockPullRequestsService(ctrl)
+	prs.EXPECT().RequestReviewers(gomock.AssignableToTypeOf(ctxInterface), pr.RepoOwner, pr.RepoName, 456, github.ReviewersRequest{Reviewers: []string{"org-member"}}).Return(nil, nil, nil)
+	s.GithubClient.PullRequests = prs
+
+	cmdOutput, err := s.doCherryPick(context.Background(), "release-5.28", nil, pr)
+	require.NoError(t, err)
+	require.Empty(t, cmdOutput)
+
+	args, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	assert.Equal(t, "upstream/release-5.28\n123\nmerge-sha\nfeature/shared-branch\n", string(args))
 }
 
 func TestGetMilestone(t *testing.T) {

--- a/server/cherry_pick_test.go
+++ b/server/cherry_pick_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -150,6 +152,75 @@ echo "https://github.com/mattermost/repo-name/pull/456"
 	args, err := os.ReadFile(argsFile)
 	require.NoError(t, err)
 	assert.Equal(t, "upstream/release-5.28\n123\nmerge-sha\nfeature/shared-branch\n", string(args))
+}
+
+func TestCherryPickScriptNamesBranchFromSourceAndTarget(t *testing.T) {
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0700))
+	repoRoot := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(repoRoot, 0700))
+
+	pushArgsFile := filepath.Join(tempDir, "push-args")
+	t.Setenv("FAKE_REPO_ROOT", repoRoot)
+	t.Setenv("GIT_PUSH_ARGS_FILE", pushArgsFile)
+	t.Setenv("GITHUB_USER", "mattermod")
+	t.Setenv("ORIGINAL_AUTHOR", "author")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	fakeGit := `#!/usr/bin/env bash
+set -e
+
+case "$1" in
+  rev-parse)
+    echo "$FAKE_REPO_ROOT"
+    ;;
+  symbolic-ref)
+    echo "master"
+    ;;
+  remote)
+    if [[ "$2" == "get-url" ]]; then
+      echo "git@github.com:mattermost/repo-name.git"
+    fi
+    ;;
+  log)
+    echo "merge-sha"
+    ;;
+  push)
+    printf "%s\n" "$@" > "$GIT_PUSH_ARGS_FILE"
+    ;;
+esac
+`
+	writeExecutableTestFile(t, filepath.Join(binDir, "git"), fakeGit)
+	writeExecutableTestFile(t, filepath.Join(binDir, "hub"), "#!/usr/bin/env bash\nexit 0\n")
+
+	cmd := exec.Command(
+		"bash",
+		filepath.Join("..", "hack", "cherry-pick.sh"),
+		"upstream/release-11.7",
+		"123",
+		"merge-sha",
+		"my-branch",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	pushArgs, err := os.ReadFile(pushArgsFile)
+	require.NoError(t, err)
+
+	args := strings.Split(strings.TrimSpace(string(pushArgs)), "\n")
+	require.Len(t, args, 3)
+	branchParts := strings.SplitN(args[2], ":", 2)
+	require.Len(t, branchParts, 2)
+	assert.Equal(t, "my-branch-release-11.7", branchParts[1])
+}
+
+func writeExecutableTestFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	// #nosec G302 -- these test command shims must be executable to appear in PATH.
+	require.NoError(t, os.Chmod(path, 0700))
 }
 
 func TestGetMilestone(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Before this PR, if I ran `/cherry-pick` in PR #37122, from branch `my-branch`, at `mattermost/mattermost` into `release-11.7`, the name of the automatically generated branch was:
```
automated-cherry-pick-of-mattermost-#37122-upstream-release-11.7
```

After this PR, it will be
```
automated-cherry-pick-of-my-branch-release-11.7
```

This unlocks using `/cherry-pick` in pairs of dependent PRs, one in `mattermost/mattermost` and one in `mattermost/enterprise`, that originally had the same branch name for CI to compile them together, so that the cherry-pick PRs also signal to CI that they need to be compiled together.

## Testing
- `bash -n hack/cherry-pick.sh` passed.
- `go test ./server -run 'TestCherryPickScriptNamesBranchFromSourceAndTarget|TestCherryPickScriptRejectsEmptySourceBranch' -count=1` passed.
- `go test ./server -count=1` passed.
- `golangci-lint run ./server` could not be run locally because `golangci-lint` is not installed in this environment.
- `go test ./...` fails in `store` integration tests because the `mysql` host is unavailable in this environment (`lookup mysql ... server misbehaving`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f82cbdbe-1ef4-4717-8ea4-8c3d24351555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f82cbdbe-1ef4-4717-8ea4-8c3d24351555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

