### PR TITLE
chore: Sync prod kustomization tags to current release v0.23.0

### DIFF
--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -27,7 +27,7 @@ secretGenerator:
 images:
   - name: mattermost/mattermod
     newName: mattermost/mattermod
-    newTag: 0.20.0
+    newTag: 0.23.0
   - name: mattermost/mattermod-jobserver
     newName: mattermost/mattermod-jobserver
-    newTag: 0.20.0
+    newTag: 0.23.0


### PR DESCRIPTION
## Summary

- The `deploy/overlays/prod/kustomization.yaml` image tags were frozen at `0.20.0` while production advanced to `v0.23.0` via GitOps Helm values in `gitops-release-devops`
- This drift caused `make patch` / `hack/release.sh` to silently fail — the `sed` replacement found no match, so `git commit` exited with "nothing to commit"
- Syncing the tags back to `0.23.0` makes `make patch` and `make minor` self-maintaining going forward

## Test plan

- [ ] Verify `make patch` completes successfully after this merges

Made with [Cursor](https://cursor.com)